### PR TITLE
Adding scripts for release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+VERSION = $(shell git describe --tags --always --dirty)
+IMG ?= amazon/amazon-ec2-metadata-mock
+IMG_TAG ?= ${VERSION}
+IMG_W_TAG = ${IMG}:${IMG_TAG}
+DOCKERHUB_USERNAME ?= ""
+DOCKERHUB_TOKEN ?= ""
+GOOS ?= linux
+GOARCH ?= amd64
+GOPROXY ?= "https://proxy.golang.org,direct"
+SUPPORTED_PLATFORMS ?= "linux/amd64,linux/arm64,linux/arm,darwin/amd64,windows/amd64"
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
 BINARY_NAME=amazon-ec2-metadata-mock
@@ -16,9 +26,44 @@ fmt:
 
 compile:
 	@echo ${MAKEFILE_PATH}
-	go build -a -ldflags '-X "${DEFAULT_VALUES_VAR}=${ENCODED_METADATA_DEFAULTS}"' -o ${BUILD_DIR_PATH}/${BINARY_NAME} ${MAKEFILE_PATH}/cmd/amazon-ec2-metadata-mock.go
+	go build -a -tags aemm${GOOS} -ldflags '-X "${DEFAULT_VALUES_VAR}=${ENCODED_METADATA_DEFAULTS}"' -o ${BUILD_DIR_PATH}/${BINARY_NAME} ${MAKEFILE_PATH}/cmd/amazon-ec2-metadata-mock.go
 
 build: create-build-dir validate-json compile
+
+build-binaries:
+	${MAKEFILE_PATH}/scripts/build-binaries -d -p ${SUPPORTED_PLATFORMS} -v ${VERSION}
+
+docker-build:
+	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${GOOS}/${GOARCH} -r ${IMG} -v ${VERSION}
+
+docker-run:
+	docker run ${IMG_W_TAG}
+
+docker-push:
+	@echo ${DOCKERHUB_TOKEN} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
+	docker push ${IMG_W_TAG}
+
+build-docker-images:
+	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION}
+
+push-docker-images:
+	@echo ${DOCKERHUB_TOKEN} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
+	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION} -m
+
+version:
+	@echo ${VERSION}
+
+image:
+	@echo ${IMG_W_TAG}
+
+upload-resources-to-github:
+	${MAKEFILE_PATH}/scripts/upload-resources-to-github
+
+generate-k8s-yaml:
+	${MAKEFILE_PATH}/scripts/generate-k8s-yaml
+
+sync-readme-to-dockerhub:
+	${MAKEFILE_PATH}/scripts/sync-readme-to-dockerhub
 
 unit-test: create-build-dir
 	go test ${MAKEFILE_PATH}/... -v -coverprofile=coverage.txt -covermode=atomic -outputdir=${BUILD_DIR_PATH}
@@ -34,5 +79,7 @@ license-test:
 
 go-report-card-test:
 	${MAKEFILE_PATH}/test/go-report-card-test/run-report-card-test.sh
+
+release: create-build-dir build-binaries build-docker-images push-docker-images generate-k8s-yaml upload-resources-to-github
 
 test: unit-test e2e-test license-test go-report-card-test

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+REPO_ROOT_PATH=$SCRIPTPATH/../
+MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
+mkdir -p $SCRIPTPATH/../build/bin
+
+VERSION=$(make -s -f $MAKE_FILE_PATH version)
+PLATFORMS=("linux/amd64")
+PASS_THRU_ARGS=""
+
+USAGE=$(cat << 'EOM'
+  Usage: build-binaries  [-p <platform pairs>]
+  Builds static binaries for the platform pairs passed in
+
+  Example: build-binaries -p "linux/amd64,linux/arm"
+          Optional:
+            -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -d          DIRECT: Set GOPROXY=direct to bypass go proxies
+            -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
+EOM
+)
+
+# Process our input arguments
+while getopts "dp:v:" opt; do
+  case ${opt} in
+    p ) # Platform Pairs
+        IFS=',' read -ra PLATFORMS <<< "$OPTARG"
+      ;;
+    d ) # sets GOPROXY=direct
+        PASS_THRU_ARGS="$PASS_THRU_ARGS -d"
+      ;;
+    v ) # Image Version
+        VERSION="$OPTARG"
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+for os_arch in "${PLATFORMS[@]}"; do
+    os=$(echo $os_arch | cut -d'/' -f1)
+    arch=$(echo $os_arch | cut -d'/' -f2)
+    container_name="extract-aemm-$os-$arch"
+    repo_name="aemm-bin"
+    bin_name="amazon-ec2-metadata-mock-$os-$arch"
+
+    docker container rm $container_name || :
+    $SCRIPTPATH/build-docker-images -p $os_arch -v $VERSION -r $repo_name $PASS_THRU_ARGS
+    docker container create --rm --name $container_name "$repo_name:$VERSION-$os-$arch"
+    docker container cp $container_name:/amazon-ec2-metadata-mock $SCRIPTPATH/../build/bin/$bin_name
+done

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+REPO_ROOT_PATH=$SCRIPTPATH/../
+MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
+
+VERSION=$(make -s -f $MAKE_FILE_PATH version)
+PLATFORMS=("linux/amd64")
+GOPROXY="https://proxy.golang.org,direct"
+
+
+USAGE=$(cat << 'EOM'
+  Usage: build-docker-images  [-p <platform pairs>]
+  Builds docker images for the platform pair
+
+  Example: build-docker-images -p "linux/amd64,linux/arm"
+          Optional:
+            -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -d          DIRECT: Set GOPROXY=direct to bypass go proxies
+            -r          IMAGE REPO: set the docker image repo
+            -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
+EOM
+)
+
+# Process our input arguments
+while getopts "dp:r:v:" opt; do
+  case ${opt} in
+    p ) # Platform Pairs
+        IFS=',' read -ra PLATFORMS <<< "$OPTARG"
+      ;;
+    d ) # GOPROXY=direct
+        GOPROXY="direct"
+      ;;
+    r ) # Image Repo
+        IMAGE_REPO="$OPTARG"
+      ;;
+    v ) # Image Version
+        VERSION="$OPTARG"
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+for os_arch in "${PLATFORMS[@]}"; do
+    os=$(echo $os_arch | cut -d'/' -f1)
+    arch=$(echo $os_arch | cut -d'/' -f2)
+
+    img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
+
+    docker build \
+        --build-arg GOOS=${os} \
+        --build-arg GOARCH=${arch} \
+        --build-arg GOPROXY=${GOPROXY} \
+        -t ${img_tag} \
+        ${REPO_ROOT_PATH}
+done

--- a/scripts/generate-k8s-yaml
+++ b/scripts/generate-k8s-yaml
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+HELM_VERSION="3.2.0"
+NAMESPACE="default"
+
+MAKEFILEPATH=$SCRIPTPATH/../Makefile
+VERSION=$(make -s -f $MAKEFILEPATH version)
+BUILD_DIR=$SCRIPTPATH/../build/k8s-resources/$VERSION
+INDV_RESOURCES_DIR=$BUILD_DIR/individual-resources
+TAR_RESOURCES_FILE=$BUILD_DIR/individual-resources.tar
+AGG_RESOURCES_YAML=$BUILD_DIR/all-resources.yaml
+mkdir -p $INDV_RESOURCES_DIR
+
+USAGE=$(cat << 'EOM'
+  Usage: generate-k8s-yaml  [-n <K8s_NAMESPACE>]
+  Generates the kubernetes yaml resource files from the helm chart
+  and places them into the build dir.
+  Example: generate-k8s-yaml -n kube-system
+          Optional:
+            -n          Kubernetes namespace
+EOM
+)
+
+# Process our input arguments
+while getopts "n:" opt; do
+  case ${opt} in
+    n ) # K8s namespace
+        NAMESPACE=$OPTARG
+      ;;
+    \? )
+        echoerr "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+curl -L https://get.helm.sh/helm-v$HELM_VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C $BUILD_DIR
+mv $BUILD_DIR/$PLATFORM-amd64/helm $BUILD_DIR/.
+rm -rf $BUILD_DIR/$PLATFORM-amd64
+chmod +x $BUILD_DIR/helm
+
+$BUILD_DIR/helm template amazon-ec2-metadata-mock \
+    --namespace $NAMESPACE \
+    $SCRIPTPATH/../helm/amazon-ec2-metadata-mock/ > $AGG_RESOURCES_YAML
+
+# remove helm annotations from template
+cat $AGG_RESOURCES_YAML | grep -v 'helm.sh\|app.kubernetes.io/managed-by: Helm' > $BUILD_DIR/helm_annotations_removed.yaml
+mv $BUILD_DIR/helm_annotations_removed.yaml $AGG_RESOURCES_YAML
+
+$BUILD_DIR/helm template amazon-ec2-metadata-mock \
+    --namespace $NAMESPACE \
+    --output-dir $INDV_RESOURCES_DIR/ \
+    $SCRIPTPATH/../helm/amazon-ec2-metadata-mock/
+
+# remove helm annotations from template
+for i in $INDV_RESOURCES_DIR/amazon-ec2-metadata-mock/templates/*; do
+  cat $i | grep -v 'helm.sh\|app.kubernetes.io/managed-by: Helm' > $BUILD_DIR/helm_annotations_removed.yaml
+  mv $BUILD_DIR/helm_annotations_removed.yaml $i
+done
+
+cd $INDV_RESOURCES_DIR/amazon-ec2-metadata-mock/ && tar cvf $TAR_RESOURCES_FILE templates/*
+cd $SCRIPTPATH
+
+echo "Generated amazon-ec2-metadata-mock kubernetes yaml resources files in:"
+echo "    - $AGG_RESOURCES_YAML"
+echo "    - $TAR_RESOURCES_FILE"

--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -10,11 +10,11 @@ VERSION=$(make -s -f $MAKE_FILE_PATH version)
 PLATFORMS=("linux/amd64")
 MANIFEST_IMAGES=""
 MANIFEST=""
+DOCKER_CLI_CONFIG="$HOME/.docker/config.json"
 
 USAGE=$(cat << 'EOM'
   Usage: push-docker-images  [-p <platform pairs>]
   Pushes docker images for the platform pairs passed in w/ a dockerhub manifest
-
   Example: push-docker-images -p "linux/amd64,linux/arm"
           Optional:
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
@@ -70,10 +70,12 @@ for os_arch in "${PLATFORMS[@]}"; do
 done
 
 if [[ $MANIFEST == "true" ]]; then
-    if [[ $(cat $HOME/.docker/config.json | jq .experimental) != "enabled" ]]; then
-        perl -i -pe's/experimental\"[ ]*\:[ ]*\"disabled\"/experimental\":\"enabled\"/g' $HOME/.docker/config.json
-        echo "Enabled experimental CLI features to create the docker manifest"
+    if [[ ! -f $DOCKER_CLI_CONFIG ]]; then
+      echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
+      echo "Created docker config file"
     fi
+    cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
+    echo "Enabled experimental CLI features to create the docker manifest"
     docker manifest create $IMAGE_REPO:$VERSION $MANIFEST_IMAGES
 
     for os_arch in "${PLATFORMS[@]}"; do

--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+REPO_ROOT_PATH=$SCRIPTPATH/../
+MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
+
+VERSION=$(make -s -f $MAKE_FILE_PATH version)
+PLATFORMS=("linux/amd64")
+MANIFEST_IMAGES=""
+MANIFEST=""
+
+USAGE=$(cat << 'EOM'
+  Usage: push-docker-images  [-p <platform pairs>]
+  Pushes docker images for the platform pairs passed in w/ a dockerhub manifest
+
+  Example: push-docker-images -p "linux/amd64,linux/arm"
+          Optional:
+            -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -r          IMAGE REPO: set the docker image repo
+            -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
+            -m          Create a docker manifest
+EOM
+)
+
+# Process our input arguments
+while getopts "mp:r:v:" opt; do
+  case ${opt} in
+    p ) # Platform Pairs
+        IFS=',' read -ra PLATFORMS <<< "$OPTARG"
+      ;;
+    r ) # Image Repo
+        IMAGE_REPO="$OPTARG"
+      ;;
+    v ) # Image Version
+        VERSION="$OPTARG"
+      ;;
+    m ) # Docker manifest
+        MANIFEST="true"
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+if [[ ${#PLATFORMS[@]} -gt 1 && $MANIFEST != "true" ]]; then
+    echo "Only one platform can be pushed if you do not create a manifest."
+    echo "Try again with the -m option"
+    exit 1
+fi
+
+for os_arch in "${PLATFORMS[@]}"; do
+    os=$(echo $os_arch | cut -d'/' -f1)
+    arch=$(echo $os_arch | cut -d'/' -f2)
+
+    img_tag_w_platform="$IMAGE_REPO:$VERSION-$os-$arch"
+
+    if [[ $MANIFEST == "true" ]]; then
+        img_tag=$img_tag_w_platform
+    else
+        img_tag="$IMAGE_REPO:$VERSION"
+        docker tag $img_tag_w_platform $img_tag
+    fi
+
+    docker push $img_tag
+    MANIFEST_IMAGES="$MANIFEST_IMAGES $img_tag"
+done
+
+if [[ $MANIFEST == "true" ]]; then
+    if [[ $(cat $HOME/.docker/config.json | jq .experimental) != "enabled" ]]; then
+        perl -i -pe's/experimental\"[ ]*\:[ ]*\"disabled\"/experimental\":\"enabled\"/g' $HOME/.docker/config.json
+        echo "Enabled experimental CLI features to create the docker manifest"
+    fi
+    docker manifest create $IMAGE_REPO:$VERSION $MANIFEST_IMAGES
+
+    for os_arch in "${PLATFORMS[@]}"; do
+        os=$(echo $os_arch | cut -d'/' -f1)
+        arch=$(echo $os_arch | cut -d'/' -f2)
+
+        img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
+
+        docker manifest annotate $IMAGE_REPO:$VERSION $img_tag --arch $arch --os $os
+    done
+
+    docker manifest push $IMAGE_REPO:$VERSION
+fi

--- a/scripts/sync-readme-to-dockerhub
+++ b/scripts/sync-readme-to-dockerhub
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+image="amazon/amazon-ec2-metadata-mock"
+
+if git --no-pager diff --name-only HEAD^ HEAD | grep 'README.md'; then
+    token=$(curl -s -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"username": "'"${DOCKERHUB_USERNAME}"'", "password": "'"${DOCKERHUB_TOKEN}"'"}' \
+        https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+    rcode=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" \
+        '{"registry":"registry-1.docker.io","full_description": $msg }' |
+            curl -s -o /dev/stderr -L -w "%{http_code}" \
+            https://hub.docker.com/v2/repositories/"${image}"/ \
+                -d @- \
+                -X PATCH \
+                -H "Content-Type: application/json" \
+                -H "Authorization: JWT ${token}")
+
+    if [[ $rcode -ge 200 && $rcode -lt 300 ]]; then
+        echo "README sync to dockerhub completed successfully"
+    else
+        echo "README sync to dockerhub failed: $rcode"
+        exit 1
+    fi
+else
+    echo "README.md did not change in the last commit. Not taking any action."
+fi

--- a/scripts/upload-resources-to-github
+++ b/scripts/upload-resources-to-github
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+VERSION=$(make -s -f $SCRIPTPATH/../Makefile version)
+BUILD_DIR=$SCRIPTPATH/../build/k8s-resources/$VERSION
+INDV_RESOURCES_DIR=$BUILD_DIR/individual-resources
+TAR_RESOURCES_FILE=$BUILD_DIR/individual-resources.tar
+AGG_RESOURCES_YAML=$BUILD_DIR/all-resources.yaml
+
+RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    https://api.github.com/repos/aws/amazon-ec2-metadata-mock/releases | \
+    jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
+
+for binary in $SCRIPTPATH/../build/bin/*; do
+    curl \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        -H "Content-Type: $(file -b --mime-type $binary)" \
+        --data-binary @$binary \
+        "https://uploads.github.com/repos/aws/amazon-ec2-metadata-mock/releases/$RELEASE_ID/assets?name=$(basename $binary)"
+done
+
+
+## Upload k8s yaml
+resourceFiles=($TAR_RESOURCES_FILE $AGG_RESOURCES_YAML)
+for resourceFile in "${resourceFiles[@]}"; do
+    curl \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        -H "Content-Type: $(file -b --mime-type $resourceFile)" \
+        --data-binary @$resourceFile \
+        "https://uploads.github.com/repos/aws/amazon-ec2-metadata-mock/releases/$RELEASE_ID/assets?name=$(basename $resourceFile)"
+done


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Porting scripts/  from nth to aemm  for **make release** target which will be called via TravisCi
* Updated Makefile with corresponding targets
* Added MacOS and Windows to SUPPORTED_PLATFORMS

*Testing:*
* Pulled in [helm changes](https://www.github.com/aws/amazon-ec2-metadata-mock/pull/6) locally
* Changed *IMG* to my private dockerhub repo
* Created test release+tag in AEMM GitHub repo
* Ran `make clean` && `make release` && `make test` successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
