### PR TITLE
Adding travis.yml for TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+---
+language: minimal
+
+services:
+- docker
+
+matrix:
+  include:
+    - stage: Test
+      language: go
+      go: "1.13.x"
+      script: make unit-test
+      env: GO111MODULE=on
+      after_success: bash <(curl -s https://codecov.io/bash) -v
+    - stage: Test
+      script: test/go-report-card-test/run-report-card-test.sh
+      env: GO_REPORT_CARD=true
+    - stage: Test
+      if: type = push AND branch = master AND env(GITHUB_TOKEN) IS present
+      script: test/license-test/run-license-test.sh
+      env: LICENSE_TEST=true
+    - stage: Test
+      script: make e2e-test
+      env: E2E_TEST=true
+    - stage: Deploy
+      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKER_USERNAME) IS present
+      script: make release
+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,7 +111,7 @@ func LoadConfigForRoot(configFileFlagName string, cmdDefaults map[string]interfa
 
 	// set up env
 	viper.AutomaticEnv()
-	viper.AllowEmptyEnv(true) // empty strings are perfectly valid values for our usecases
+	viper.AllowEmptyEnv(true)  // empty strings are perfectly valid values for our usecases
 	viper.SetEnvPrefix("aemm") // AEMM stands for amazon-ec2-metadata-mock, set prefix to avoid name clashes
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Adding .travis.yml
  - replaced helm-sync-test with e2e-test
  - removed Deploy::sync-readme-to-dockerhub for now as README is too long to upload via API
- Fixed spacing in config.go to pass go-report-card

*Testing:*
- make clean && make build && make test succeed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
