### PR TITLE
Upgrade go version to v1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
     - stage: Test
       language: go
-      go: "1.13.x"
+      go: "1.14.x"
       script: make unit-test
       env: GO111MODULE=on
       after_success: bash <(curl -s https://codecov.io/bash) -v
@@ -20,8 +20,10 @@ matrix:
       script: test/license-test/run-license-test.sh
       env: LICENSE_TEST=true
     - stage: Test
+      language: go
+      go: "1.14.x"
       script: make e2e-test
-      env: E2E_TEST=true
+      env: E2E_TEST=true GO111MODULE=on
     - stage: Deploy
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKER_USERNAME) IS present
       script: make release

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
 # Amazon EC2 Metadata Mock: Build Instructions
 
-## Install Go version 1.13+
+## Install Go version 1.14+
 
 There are several options for installing go:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <br/>
 <p>
-   <a href="https://golang.org/doc/go1.13">
+   <a href="https://golang.org/doc/go1.14">
    <img src="https://img.shields.io/github/go-mod/go-version/aws/amazon-ec2-metadata-mock?color=blueviolet" alt="go-version">
    </a>
    <a href="https://opensource.org/licenses/Apache-2.0">

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-ec2-metadata-mock
 
-go 1.13
+go 1.14
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Upgrading go version to latest
* Updated travis.yml's make e2e-test target. It requires reference to go and gomodule because a build is kicked off beforehand (via make compile)

*Testing:*
* make clean && make build && make test succeeds
* kicked off custom build on travisci with travis.yml updates and tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
