### PR TITLE
Updating run-license-test

### DIFF
--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-BUILD_BIN="$SCRIPTPATH/../../build"
+BUILD_BIN="$SCRIPTPATH/../../build/bin"
 
-BINARY_NAME="amazon-ec2-metadata-mock"
+BINARY_NAME="amazon-ec2-metadata-mock-linux-amd64"
 LICENSE_TEST_TAG="aemm-license-test"
 
-make -s -f $SCRIPTPATH/../../Makefile build
+SUPPORTED_PLATFORMS="linux/amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
 docker build --build-arg=GOPROXY=direct -t $LICENSE_TEST_TAG $SCRIPTPATH/
 docker run -it -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/aemm-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /aemm-bin/$BINARY_NAME


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Updating run-license-test to use **make build-binaries** instead of **make build** because the latter will cause travisci to fail the build without explicit references to go in the yml file. The former executes the build in a docker container. 7th build is definitely going to pass!!

*Testing:*
- make clean && make build && make test
  - make license-test passes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
