### PR TITLE
Reorganizing README to be compliant with DockerHub upload limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
       script: test/go-report-card-test/run-report-card-test.sh
       env: GO_REPORT_CARD=true
     - stage: Test
+      script: make validate-readme
+      env: VALIDATE_README=true
+    - stage: Test
       if: type = push AND branch = master AND env(GITHUB_TOKEN) IS present
       script: test/license-test/run-license-test.sh
       env: LICENSE_TEST=true

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ e2e-test: build
 validate-json:
 	${MAKEFILE_PATH}/test/json-validator
 
+validate-readme:
+	${MAKEFILE_PATH}/test/readme-validator
+
 license-test:
 	${MAKEFILE_PATH}/test/license-test/run-license-test.sh
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,139 @@
+# AEMM Configuration
+This page serves as documentation for AEMM's configuration details.
+
+## Configuring AEMM
+The tool can be configured in various ways:
+
+1. CLI flags
+
+    Use help commands to learn more
+
+2. Env variables
+    ```
+    $ export AEMM_MOCK_DELAY_SEC=12
+    $ export AEMM_SPOT_ITN_INSTANCE_ACTION=stop
+    $ env | grep AEMM     // To list the tool's env variables
+    ```
+
+    > NOTE the translation of config key `spot-itn.instance-action` to `AEMM_SPOT_ITN_INSTANCE_ACTION` env variable.
+
+3. Configuration file in JSON format at `path/to/config-overrides.json`
+```
+{
+  "metadata": {
+    "paths": {
+        "ipv4-associations": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:77/ipv4-associations/192.0.2.54"
+    },
+    "values": {
+      "mac": "0e:49:61:0f:c3:77",
+      "public-ipv4": "54.92.157.77"
+    }
+  },
+  "spot-itn": {
+    "instance-action": "terminate",
+    "time": "2020-01-07T01:03:47Z"
+  }
+}
+```
+
+Use the `-c` flag to consume the configuration file and the `-s` flag to save an output of the configurations used by AEMM after precedence has been applied:
+
+```
+$ amazon-ec2-metadata-mock -c path/to/config-overrides.json -s
+Successfully saved final configuration to local file  /path/to/home/.amazon-ec2-metadata-mock/.aemm-config-used.json
+
+
+$ cat $HOME/.amazon-ec2-metadata-mock/.aemm-config-used.json
+(truncated for readability)
+
+{
+  "config-file": "path/to/config-overrides.json",
+  "metadata": {
+    "paths": {
+      "ipv4-associations": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:77/ipv4-associations/192.0.2.54"
+    },
+    "values": {
+      "mac": "0e:49:61:0f:c3:77",
+      "public-ipv4": "54.92.157.77"
+    }
+  },
+  "mock-delay-sec": 12,
+  "save-config-to-file": true,
+  "server": {
+    "hostname": "localhost",
+    "port": "1338"
+  },
+  "spot-itn": {
+    "instance-action": "stop",
+    "time": "2020-01-07T01:03:47Z"
+  }
+}
+
+```
+
+## Precedence (Highest to Lowest)
+1. overrides
+2. flag
+3. env
+4. config
+5. key/value store
+6. default
+
+For example, if values from the following sources were loaded:
+```
+Defaults in code:
+{
+    "config-file": "$HOME/aemm-config.json", # by default, AEMM looks here for a config file
+    "server": {
+         "port": "1338"
+    },
+    "mock-delay-sec": 0,
+    "save-config-to-file": false,
+    "spot-itn": {
+       "instance-action": "terminate"
+    }
+}
+
+Env variables:
+export AEMM_MOCK_DELAY_SEC=12
+export AEMM_SPOT_ITN_INSTANCE_ACTION=hibernate
+export AEMM_CONFIG_FILE=/path/to/my-custom-aemm-config.json
+
+Config File (at /path/to/my-custom-aemm-config.json):
+{
+    "imdsv2": true,
+    "server": {
+         "port": "1550"
+    },
+    "spot-itn": {
+       "instance-action": "stop"
+    }
+}
+
+CLI Flags:
+ {
+   "mock-delay-sec": 8
+ }
+```
+
+The resulting config will have the following values (non-overriden values are truncated for readability):
+```
+ {
+    "mock-delay-sec": 8,                                        # from CLI flag
+    "config-file": "/path/to/my-custom-aemm-config.json",       # from env
+    "spot-itn": {
+        "instance-action": "hibernate"                          # from env
+   }
+    "imdsv2": true,                                             # from custom config file at /path/to/my-custom-aemm-config.json
+     "server": {
+        "port": "1550"                                          # from custom config file at /path/to/my-custom-aemm-config.json
+    },
+    "save-config-to-file": false,                               # from defaults in code
+ }
+```
+
+AEMM is built using Viper which is where the precedence is sourced from. More details can be found in their documentation: 
+
+<a href="https://github.com/spf13/viper/blob/master/README.md">
+    <img src="https://img.shields.io/badge/viper-documentation-green" alt="">
+</a>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,192 @@
+# AEMM Usage
+This page serves as documentation for AEMM's advanced use cases and behavior.
+
+
+## Commands
+AEMM's supported commands (`spotitn`, `scheduledevents`) are viewed using `--help`:
+```
+$ amazon-ec2-metadata-mock --help
+
+...
+Available Commands:
+  help            Help about any command
+  scheduledevents Mock EC2 Scheduled Events
+  spotitn         Mock EC2 Spot interruption notice
+
+...
+```
+commands are designed as follows:
+* Run independently from other commands
+  * i.e. when AEMM is started with `scheduledevents` subcommand, `spotitn` routes will **NOT** be available and vice-versa 
+* Local flag availability so that commands can be configured directly via CLI parameters
+    * With validation checks
+* Contain additional `--help` documentation
+* Default values sourced from code
+
+Metadata categories that are always available, irrespective of the CLI command run are referred to as **static metadata**.
+
+### Spot Interruption
+To view the available flags for the Spot Interruption command use `spotitn --help`:
+```
+$ amazon-ec2-metadata-mock spotitn --help
+Mock EC2 Spot interruption notice
+
+Usage:
+  amazon-ec2-metadata-mock spotitn [--instance-action ACTION] [flags]
+
+Aliases:
+  spotitn, spot, spot-itn, spotItn
+
+Examples:
+  amazon-ec2-metadata-mock spotitn -h 	spotitn help
+  amazon-ec2-metadata-mock spotitn -d 5 --instance-action terminate		mocks spot interruption only
+
+Flags:
+  -h, --help                      help for spotitn
+  -a, --instance-action string    instance action in the spot interruption notice (default: terminate)
+                                  instance-action can be one of the following: terminate,hibernate,stop
+  -t, --termination-time string   termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
+
+Global Flags:
+  -c, --config-file string    config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -n, --hostname string       the HTTP hostname for the mock url (default: localhost)
+  -I, --imdsv2                whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int    mock delay in seconds, relative to the application start time (default: 0 seconds)
+  -p, --port string           the HTTP port where the mock runs (default: 1338)
+  -s, --save-config-to-file   whether to save processed config from all input sources in .amazon-ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+```
+
+1.) **Overriding `spotitn::instance-action` via CLI flag**:
+
+```
+$ amazon-ec2-metadata-mock spotitn -a stop
+Initiating amazon-ec2-metadata-mock for EC2 Spot interruption notice on port 1338
+
+Flags:
+instance-action: stop
+
+Serving the following routes: ... (truncated for readability)
+```
+
+Send the request:
+```
+$ curl localhost:1338/latest/meta-data/spot/instance-action
+{
+	"instance-action": "stop",
+	"time": "2020-04-24T17:11:44Z"
+}
+```
+
+### Scheduled Events
+Similar to spotitn, the `scheduledevents` command, view the local flags using `scheduledevents --help`:
+
+```
+$ amazon-ec2-metadata-mock scheduledevents --help
+Mock EC2 Scheduled Events
+
+Usage:
+  amazon-ec2-metadata-mock scheduledevents [--code CODE] [--state STATE] [--not-after] [--not-before-deadline] [flags]
+
+Aliases:
+  scheduledevents, se, scheduled-events, scheduledEvents
+
+Examples:
+  amazon-ec2-metadata-mock scheduledevents -h 	scheduledevents help
+  amazon-ec2-metadata-mock scheduledevents -o instance-stop --state active -d		mocks an active and upcoming scheduled event for instance stop with a deadline for the event start time
+
+Flags:
+  -o, --code string                  event code in the scheduled event (default: system-reboot)
+                                     event-code can be one of the following: instance-reboot,system-reboot,system-maintenance,instance-retirement,instance-stop
+  -h, --help                         help for scheduledevents
+  -a, --not-after string             the latest end time for the scheduled event in RFC3339 format E.g. 2020-01-07T01:03:47Z default: application start time + 7 days in UTC))
+  -b, --not-before string            the earliest start time for the scheduled event in RFC3339 format E.g. 2020-01-07T01:03:47Z (default: application start time in UTC)
+  -l, --not-before-deadline string   the deadline for starting the event in RFC3339 format E.g. 2020-01-07T01:03:47Z (default: application start time + 9 days in UTC)
+  -t, --state string                 state of the scheduled event (default: active)
+                                     state can be one of the following: active,completed,canceled
+
+(Truncated Global Flags for readability)
+```
+
+1.) **Starting AEMM with `scheduledevents` invalid flag overrides**: as noted above, all commands have validation logic for overrides via CLI flags. If the user attempts to pass an invalid override value, then AEMM will panic, kill the server, and return an error message with what went wrong:
+
+```
+$ amazon-ec2-metadata-mock scheduledevents --code FOO
+
+panic: Fatal error while executing the root command: Invalid CLI input "FOO" for flag code. 
+Allowed value(s): instance-reboot,system-reboot,system-maintenance,instance-retirement,instance-stop.
+```
+
+## Static Metadata
+Additional properties of static metadata:
+* delays do **NOT** affect static metadata availability
+* values are overridden via config file and/or env variables **only**
+  * values **cannot** be overridden using flags
+
+
+### Static Metadata Overrides & Path Substitutions
+Some metadata categories use data unique to the instance as part of the query.
+* **Example:**  network/interfaces/macs/*MAC*/interface-id where *MAC* is a placeholder for the instance's mac address
+  * [AWS Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html)
+
+Applying overrides to these *placeholder values* will automatically update paths containing these values **unless** the path itself is explicitly overridden.
+
+1.) **Starting AEMM with JSON config overrides:** The static metadata will use the overridden values AND paths using overridden instance data will be updated as well.
+
+* config-overrides.json:
+
+```
+{
+    "metadata": {
+        "paths": {
+            "mac-device-number": "/latest/meta-data/network/interfaces/macs/BAR/device-number"
+        },
+        "values": {
+            "mac": "FOO"
+        }
+    }
+}
+
+```
+
+* start the server with overrides:
+
+```
+$ amazon-ec2-metadata-mock -c config-overrides.json
+Initiating amazon-ec2-metadata-mock for all mocks on port 1338
+
+Flags:
+config-file: config-overrides.json
+```
+
+* querying the available routes will show updated placeholder paths **except** for those explicitly overridden in the "paths" blob of *config-overrides.json*:
+
+```
+$ curl localhost:1338/latest/meta-data
+
+network/interfaces/macs/BAR/device-number
+network/interfaces/macs/FOO/interface-id
+network/interfaces/macs/FOO/ipv4-associations/192.0.2.54
+network/interfaces/macs/FOO/ipv6s
+network/interfaces/macs/FOO/local-hostname
+network/interfaces/macs/FOO/local-ipv4s
+network/interfaces/macs/FOO/mac
+network/interfaces/macs/FOO/owner-id
+network/interfaces/macs/FOO/public-hostname
+network/interfaces/macs/FOO/public-ipv4s
+network/interfaces/macs/FOO/security-group-ids
+network/interfaces/macs/FOO/security-groups
+network/interfaces/macs/FOO/subnet-id
+network/interfaces/macs/FOO/subnet-ipv4-cidr-block
+network/interfaces/macs/FOO/subnet-ipv6-cidr-blocks
+network/interfaces/macs/FOO/vpc-id
+network/interfaces/macs/FOO/vpc-ipv4-cidr-block
+network/interfaces/macs/FOO/vpc-ipv4-cidr-blocks
+network/interfaces/macs/FOO/vpc-ipv6-cidr-blocks
+```
+
+* querying the mac address will reflect overridden value:
+
+```
+$ curl http://localhost:1338/latest/meta-data/mac
+FOO
+```

--- a/scripts/sync-readme-to-dockerhub
+++ b/scripts/sync-readme-to-dockerhub
@@ -8,7 +8,7 @@ image="amazon/amazon-ec2-metadata-mock"
 if git --no-pager diff --name-only HEAD^ HEAD | grep 'README.md'; then
     token=$(curl -s -X POST \
         -H "Content-Type: application/json" \
-        -d '{"username": "'"${DOCKERHUB_USERNAME}"'", "password": "'"${DOCKERHUB_TOKEN}"'"}' \
+        -d '{"username": "'"${DOCKERHUB_USERNAME}"'", "password": "'"${DOCKERHUB_PASSWORD}"'"}' \
         https://hub.docker.com/v2/users/login/ | jq -r .token)
 
     rcode=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" \

--- a/test/readme-validator
+++ b/test/readme-validator
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+README_FILES=$(find $SCRIPTPATH/../ -name "*.md" -type f)
+MAX_CHAR_COUNT=25000
+
+for r in $README_FILES; do
+  echo "validating $r"
+  chars=$( wc -m < "$r" )
+  if [[ $chars -ge $MAX_CHAR_COUNT ]]; then
+    echo "$r exceeds max character count"
+    exit 1
+  fi
+done


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Updated README.md to be within DockerHub upload character count limit (25000). Updated char count: 20911
* Added *readme-validator* to ensure readme files are below max char count-- this will be invoked by **travisci** for all PRs
* Updated sync-readme-to-dockerhub to use $DOCKERHUB_PASSWORD instead of TOKEN as the token is **not** supported per [this issue](https://github.com/peter-evans/dockerhub-description/issues/10)
* Kept common use cases and high-level descriptions in main README and moved advanced usage and configuration details to docs/usage.md and docs/configuration.md, respectively.
* When adding more installation methods, we can create installation.md at that time if we are approaching char limit in main README.
* Although the main README.md will be the only one synced with DockerHub, validating all .md files to keep them from getting too lengthy

*Testing:*
* make clean && make build && make test succeed
* tested *make sync-readme-to-dockerhub* on new README with private repo; upload was successful
* tested *make validate-readme* on current ReadMes and passed. Also tested on old README (exceeding char count) and test failed as expected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
