### PR TITLE
Add Docker notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/relea
 curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.3/ec2-metadata-mock-windows-amd64
 ```
 
+### Docker
+```
+docker pull amazon/amazon-ec2-metadata-mock
+```
+
+Note, when running on Windows or Mac, you will need to change the default bind hostname from localhost because the binary runs in
+a virtual machine, e.g.,
+
+```
+docker run -it --rm amazon/amazon-ec2-metadata-mock --hostname 0.0.0.0
+```
+
 ## Starting AEMM
 Use `ec2-metadata-mock --help` to view examples and explanations of supported flags and commands:
 

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/relea
 
 ### Docker
 ```
-docker pull amazon/amazon-ec2-metadata-mock
+docker pull amazon/amazon-ec2-metadata-mock:v0.9.3
 ```
 
 Note, when running on Windows or Mac, you will need to change the default bind hostname from localhost because the binary runs in
 a virtual machine, e.g.,
 
 ```
-docker run -it --rm amazon/amazon-ec2-metadata-mock --hostname 0.0.0.0
+docker run -it --rm amazon/amazon-ec2-metadata-mock:v0.9.3 --hostname 0.0.0.0
 ```
 
 ## Starting AEMM

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note, when running on Windows or Mac, you will need to change the default bind h
 a virtual machine, e.g.,
 
 ```
-docker run -it --rm amazon/amazon-ec2-metadata-mock:v0.9.3 --hostname 0.0.0.0
+docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.3 --hostname 0.0.0.0
 ```
 
 ## Starting AEMM


### PR DESCRIPTION
*Description of changes:*

Adds a section about Docker to the readme. I noticed there's a docker image and tried it out, but initially couldn't get it to work because on Mac (and Windows), the default hostname won't work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
