### PR TITLE
change default hostname so zero config cli works on docker

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -68,7 +68,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	// global flags
-	cmd.PersistentFlags().StringP(gf.HostNameFlag, "n", "", "the HTTP hostname for the mock url (default: localhost)")
+	cmd.PersistentFlags().StringP(gf.HostNameFlag, "n", "", "the HTTP hostname for the mock url (default: 0.0.0.0)")
 	cmd.PersistentFlags().StringP(gf.PortFlag, "p", "", "the HTTP port where the mock runs (default: 1338)")
 	cmd.PersistentFlags().StringP(gf.ConfigFileFlag, "c", "", "config file for cli input parameters in json format (default: "+cfg.GetDefaultCfgFileName()+")")
 	cmd.PersistentFlags().BoolP(gf.SaveConfigToFileFlag, "s", false, "whether to save processed config from all input sources in "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -20,7 +20,7 @@ import (
 var (
 	serverCfgPrefix   = "server."
 	serverCfgDefaults = map[string]interface{}{
-		serverCfgPrefix + "hostname": "localhost",
+		serverCfgPrefix + "hostname": "0.0.0.0",
 		serverCfgPrefix + "port":     "1338",
 	}
 )


### PR DESCRIPTION
*Description of changes:*
* change default hostname so zero config cli works on docker

Readme changes will follow in a subsequent PR. 

*Related PRs*: https://github.com/aws/amazon-ec2-metadata-mock/pull/19


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
