### PR TITLE
Addressing issues before v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ $ curl localhost:1338/latest/meta-data/events/maintenance/scheduled
 	"Code": "instance-reboot",
 	"Description": "The instance is scheduled for instance-reboot",
 	"State": "completed",
-	"EventID": "instance-event-1234567890abcdef0",
+	"EventId": "instance-event-1234567890abcdef0",
 	"NotBefore": "1 Jan 2020 01:03:47 GMT",
 	"NotAfter": "7 Jan 2020 01:03:47 GMT",
 	"NotBeforeDeadline": "10 Jan 2020 01:03:47 GMT"

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ Usage:
 
 Examples:
   ec2-metadata-mock --mock-delay-sec 10	mocks all metadata paths
-  ec2-metadata-mock spotitn --instance-action terminate	mocks spot ITN only
+  ec2-metadata-mock spot --instance-action terminate	mocks spot ITN only
 
 Available Commands:
   help            Help about any command
   scheduledevents Mock EC2 Scheduled Events
-  spotitn         Mock EC2 Spot interruption notice
+  spot            Mock EC2 Spot interruption notice
 
 Flags:
   -c, --config-file string    config file for cli input parameters in json format (default: $HOME/aemm-config.json)
@@ -225,23 +225,23 @@ AEMM is primarily used as a developer tool to help test behavior related to Meta
 and requesting static metadata. This section outlines the common use cases of AEMM; advanced usage and behavior are documented [here](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/docs/usage.md).
 
 ## Spot Interruption
-To view the available flags for the Spot Interruption command use `spotitn --help`:
+To view the available flags for the Spot Interruption command use `spot --help`:
 ```
-$ ec2-metadata-mock spotitn --help
+$ ec2-metadata-mock spot --help
 Mock EC2 Spot interruption notice
 
 Usage:
-  ec2-metadata-mock spotitn [--instance-action ACTION] [flags]
+  ec2-metadata-mock spot [--instance-action ACTION] [flags]
 
 Aliases:
-  spotitn, spot, spot-itn, spotItn
+  spot, spotitn
 
 Examples:
-  ec2-metadata-mock spotitn -h 	spotitn help
-  ec2-metadata-mock spotitn -d 5 --instance-action terminate		mocks spot interruption only
+  ec2-metadata-mock spot -h 	spot help
+  ec2-metadata-mock spot -d 5 --instance-action terminate		mocks spot interruption only
 
 Flags:
-  -h, --help                      help for spotitn
+  -h, --help                      help for spot
   -a, --instance-action string    instance action in the spot interruption notice (default: terminate)
                                   instance-action can be one of the following: terminate,hibernate,stop
   -t, --termination-time string   termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
@@ -255,9 +255,9 @@ Global Flags:
   -s, --save-config-to-file   whether to save processed config from all input sources in .amazon-ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
 ```
 
-1.) **Starting AEMM with `spotitn`**:  `spotitn` routes available immediately:
+1.) **Starting AEMM with `spot`**:  `spot` routes available immediately:
 ```
-$ ec2-metadata-mock spotitn
+$ ec2-metadata-mock spot
 Initiating ec2-metadata-mock for EC2 Spot interruption notice on port 1338
 Serving the following routes: ... (truncated for readability)
 ```
@@ -271,10 +271,10 @@ $ curl localhost:1338/latest/meta-data/spot/instance-action
 ```
 
 
-2.) **Starting AEMM with `spotitn` after Delay**: Users can apply a *delay* duration in seconds for when the `spotitn` metadata will become available:
+2.) **Starting AEMM with `spot` after Delay**: Users can apply a *delay* duration in seconds for when the `spot` metadata will become available:
 
 ```
-$ ec2-metadata-mock spotitn -d 10
+$ ec2-metadata-mock spot -d 10
 Initiating ec2-metadata-mock for EC2 Spot interruption notice on port 1338
 
 Flags:
@@ -283,7 +283,7 @@ mock-delay-sec: 10
 Serving the following routes: ... (truncated for readability)
 ```
 
-Sending a request to `spotitn` paths before the delay has passed will return **404 - Not Found:**
+Sending a request to `spot` paths before the delay has passed will return **404 - Not Found:**
 ```
 $ curl localhost:1338/latest/meta-data/spot/instance-action
 
@@ -304,7 +304,7 @@ $ curl localhost:1338/latest/meta-data/spot/instance-action
 Delaying the response by 10s as requested. The mock response will be avaiable in 2s. Returning `notFoundResponse` for now
 ```
 
-Once the delay is complete, querying `spotitn` paths return expected results:
+Once the delay is complete, querying `spot` paths return expected results:
 ```
 $ curl localhost:1338/latest/meta-data/spot/instance-action
 
@@ -316,7 +316,7 @@ $ curl localhost:1338/latest/meta-data/spot/instance-action
 ```
 
 ## Scheduled Events
-Similar to spotitn, the `scheduledevents` command, view the local flags using `scheduledevents --help`:
+Similar to spot, the `scheduledevents` command, view the local flags using `scheduledevents --help`:
 
 ```
 $ ec2-metadata-mock scheduledevents --help
@@ -345,7 +345,7 @@ Flags:
 (Truncated Global Flags for readability)
 ```
 
-1.) **Starting AEMM with `scheduledevents`**: `scheduledevents` route available immediately and `spotitn` routes will no longer be available due to the implementation of Commands [detailed here](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/docs/usage.md):
+1.) **Starting AEMM with `scheduledevents`**: `scheduledevents` route available immediately and `spot` routes will no longer be available due to the implementation of Commands [detailed here](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/docs/usage.md):
 
 ```
 $ ec2-metadata-mock scheduledevents --code instance-reboot -a 2020-01-07T01:03:47Z  -b 2020-01-01T01:03:47Z -l 2020-01-10T01:03:47Z --state completed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,7 @@ This page serves as documentation for AEMM's advanced use cases and behavior.
 
 
 ## Commands
-AEMM's supported commands (`spotitn`, `scheduledevents`) are viewed using `--help`:
+AEMM's supported commands (`spot`, `scheduledevents`) are viewed using `--help`:
 ```
 $ ec2-metadata-mock --help
 
@@ -11,13 +11,13 @@ $ ec2-metadata-mock --help
 Available Commands:
   help            Help about any command
   scheduledevents Mock EC2 Scheduled Events
-  spotitn         Mock EC2 Spot interruption notice
+  spot            Mock EC2 Spot interruption notice
 
 ...
 ```
 commands are designed as follows:
 * Run independently from other commands
-  * i.e. when AEMM is started with `scheduledevents` subcommand, `spotitn` routes will **NOT** be available and vice-versa 
+  * i.e. when AEMM is started with `scheduledevents` subcommand, `spot` routes will **NOT** be available and vice-versa 
 * Local flag availability so that commands can be configured directly via CLI parameters
     * With validation checks
 * Contain additional `--help` documentation
@@ -26,23 +26,23 @@ commands are designed as follows:
 Metadata categories that are always available, irrespective of the CLI command run are referred to as **static metadata**.
 
 ### Spot Interruption
-To view the available flags for the Spot Interruption command use `spotitn --help`:
+To view the available flags for the Spot Interruption command use `spot --help`:
 ```
-$ ec2-metadata-mock spotitn --help
+$ ec2-metadata-mock spot --help
 Mock EC2 Spot interruption notice
 
 Usage:
-  ec2-metadata-mock spotitn [--instance-action ACTION] [flags]
+  ec2-metadata-mock spot [--instance-action ACTION] [flags]
 
 Aliases:
-  spotitn, spot, spot-itn, spotItn
+  spot, spotitn
 
 Examples:
-  ec2-metadata-mock spotitn -h 	spotitn help
-  ec2-metadata-mock spotitn -d 5 --instance-action terminate		mocks spot interruption only
+  ec2-metadata-mock spot -h 	spot help
+  ec2-metadata-mock spot -d 5 --instance-action terminate		mocks spot interruption only
 
 Flags:
-  -h, --help                      help for spotitn
+  -h, --help                      help for spot
   -a, --instance-action string    instance action in the spot interruption notice (default: terminate)
                                   instance-action can be one of the following: terminate,hibernate,stop
   -t, --termination-time string   termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
@@ -56,10 +56,10 @@ Global Flags:
   -s, --save-config-to-file   whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
 ```
 
-1.) **Overriding `spotitn::instance-action` via CLI flag**:
+1.) **Overriding `spot::instance-action` via CLI flag**:
 
 ```
-$ ec2-metadata-mock spotitn -a stop
+$ ec2-metadata-mock spot -a stop
 Initiating amazon-ec2-metadata-mock for EC2 Spot interruption notice on port 1338
 
 Flags:
@@ -78,7 +78,7 @@ $ curl localhost:1338/latest/meta-data/spot/instance-action
 ```
 
 ### Scheduled Events
-Similar to spotitn, the `scheduledevents` command, view the local flags using `scheduledevents --help`:
+Similar to spot, the `scheduledevents` command, view the local flags using `scheduledevents --help`:
 
 ```
 $ ec2-metadata-mock scheduledevents --help
@@ -88,7 +88,7 @@ Usage:
   ec2-metadata-mock scheduledevents [--code CODE] [--state STATE] [--not-after] [--not-before-deadline] [flags]
 
 Aliases:
-  scheduledevents, se, scheduled-events, scheduledEvents
+  scheduledevents, se
 
 Examples:
   ec2-metadata-mock scheduledevents -h 	scheduledevents help

--- a/pkg/cmd/cmdutil/cmdutil.go
+++ b/pkg/cmd/cmdutil/cmdutil.go
@@ -114,17 +114,17 @@ func getHandlerPairs(cmd *cobra.Command, config cfg.Config) []handlerPair {
 		{path: "/latest/meta-data/", handler: listmocks.Handler},
 	}
 
-	isSpot := strings.Contains(cmd.Name(), "spotitn")
+	isSpot := strings.Contains(cmd.Name(), "spot")
 	isSchedEvents := strings.Contains(cmd.Name(), "scheduledevents")
 
 	subCommandHandlers := map[string][]handlerPair{
-		"spotitn": {{path: config.Metadata.Paths.SpotItn, handler: spotitn.Handler},
+		"spot": {{path: config.Metadata.Paths.SpotItn, handler: spotitn.Handler},
 			{path: config.Metadata.Paths.SpotItnTerminationTime, handler: spotitn.Handler}},
 		"scheduledevents": {{path: config.Metadata.Paths.ScheduledEvents, handler: scheduledevents.Handler}},
 	}
 
 	if isSpot {
-		handlerPairs = append(handlerPairs, subCommandHandlers["spotitn"]...)
+		handlerPairs = append(handlerPairs, subCommandHandlers["spot"]...)
 	} else if isSchedEvents {
 		handlerPairs = append(handlerPairs, subCommandHandlers["scheduledevents"]...)
 	} else {

--- a/pkg/cmd/root/root_test.go
+++ b/pkg/cmd/root/root_test.go
@@ -43,7 +43,7 @@ func TestNewCmdFlags(t *testing.T) {
 	h.ItemsMatch(t, expectedFlags, actualFlags)
 }
 func TestNewCmdHasSubcommands(t *testing.T) {
-	expSubcommandNames := []string{"spotitn", "scheduledevents"}
+	expSubcommandNames := []string{"spot", "scheduledevents"}
 
 	cmd := NewCmd()
 	actSubcommands := cmd.Commands()

--- a/pkg/cmd/scheduledevents/scheduledevents.go
+++ b/pkg/cmd/scheduledevents/scheduledevents.go
@@ -91,7 +91,7 @@ func initConfig() {
 func newCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "scheduledevents [--code CODE] [--state STATE] [--not-after] [--not-before-deadline]",
-		Aliases: []string{"se", "scheduled-events", "scheduledEvents"},
+		Aliases: []string{"se"},
 		PreRunE: preRun,
 		Example: fmt.Sprintf("  %s scheduledevents -h \tscheduledevents help \n  %s scheduledevents -o instance-stop --state active -d\t\tmocks an active and upcoming scheduled event for instance stop with a deadline for the event start time", cmdutil.BinName, cmdutil.BinName),
 		Run:     run,

--- a/pkg/cmd/spotitn/spotitn.go
+++ b/pkg/cmd/spotitn/spotitn.go
@@ -66,10 +66,10 @@ func initConfig() {
 
 func newCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "spotitn [--instance-action ACTION]",
-		Aliases: []string{"spot", "spot-itn", "spotItn"},
+		Use:     "spot [--instance-action ACTION]",
+		Aliases: []string{"spotitn"},
 		PreRunE: preRun,
-		Example: fmt.Sprintf("  %s spotitn -h \tspotitn help \n  %s spotitn -d 5 --instance-action terminate\t\tmocks spot interruption only", cmdutil.BinName, cmdutil.BinName),
+		Example: fmt.Sprintf("  %s spot -h \tspot help \n  %s spot -d 5 --instance-action terminate\t\tmocks spot interruption only", cmdutil.BinName, cmdutil.BinName),
 		Run:     run,
 		Short:   "Mock EC2 Spot interruption notice",
 		Long:    "Mock EC2 Spot interruption notice",

--- a/pkg/cmd/spotitn/spotitn_test.go
+++ b/pkg/cmd/spotitn/spotitn_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestNewCmdName(t *testing.T) {
-	expected := "spotitn"
+	expected := "spot"
 	actual := newCmd().Name()
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for spotitn command to be %s, but was %s", expected, actual))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -126,7 +126,7 @@ func LoadConfigForRoot(configFileFlagName string, cmdDefaults map[string]interfa
 		case viper.ConfigFileNotFoundError:
 			log.Println("Warning: ", err)
 		default:
-			log.Printf("Error while attempting to read config from %s: %s\n", viper.ConfigFileUsed(), err)
+			log.Fatalf("Error while attempting to apply overrides from %s: %s\n", viper.ConfigFileUsed(), err)
 		}
 	} else {
 		fmt.Println("Using configuration from file: ", viper.ConfigFileUsed())

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -116,7 +116,7 @@ type Values struct {
 	BlockDeviceMappingSwap       string                            `mapstructure:"block-device-mapping-swap"`
 	ElasticInferenceAccelerator  types.ElasticInferenceAccelerator `mapstructure:"elastic-inference-accelerator"`
 	ElasticInferenceAssociations string                            `mapstructure:"elastic-inference-associations"`
-	EventID                      string                            `mapstructure:"event-id"`
+	EventId                      string                            `mapstructure:"event-id"`
 	Hostname                     string                            `mapstructure:"hostname"`
 	IamInformation               types.IamInformation              `mapstructure:"iam-info"`
 	IamSecurityCredentialsRole   string                            `mapstructure:"iam-security-credentials-role"`

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -116,7 +116,7 @@ type Values struct {
 	BlockDeviceMappingSwap       string                            `mapstructure:"block-device-mapping-swap"`
 	ElasticInferenceAccelerator  types.ElasticInferenceAccelerator `mapstructure:"elastic-inference-accelerator"`
 	ElasticInferenceAssociations string                            `mapstructure:"elastic-inference-associations"`
-	EventId                      string                            `mapstructure:"event-id"`
+	EventID                      string                            `mapstructure:"event-id" json:"EventId"`
 	Hostname                     string                            `mapstructure:"hostname"`
 	IamInformation               types.IamInformation              `mapstructure:"iam-info"`
 	IamSecurityCredentialsRole   string                            `mapstructure:"iam-security-credentials-role"`

--- a/pkg/mock/scheduledevents/internal/types/types.go
+++ b/pkg/mock/scheduledevents/internal/types/types.go
@@ -18,7 +18,7 @@ type Event struct {
 	Code              string `mapstructure:"code"`
 	Description       string `mapstructure:"description"`
 	State             string `mapstructure:"state"` // State of the scheduled event
-	EventId           string `mapstructure:"event-id"`
+	EventID           string `mapstructure:"event-id" json:"EventId"`
 	NotBefore         string `mapstructure:"not-before"`                    // The earliest start time for the scheduled event
 	NotAfter          string `mapstructure:"not-after,omitempty"`           // The latest end time for the scheduled event
 	NotBeforeDeadline string `mapstructure:"not-before-deadline,omitempty"` // The deadline for starting the event

--- a/pkg/mock/scheduledevents/internal/types/types.go
+++ b/pkg/mock/scheduledevents/internal/types/types.go
@@ -18,7 +18,7 @@ type Event struct {
 	Code              string `mapstructure:"code"`
 	Description       string `mapstructure:"description"`
 	State             string `mapstructure:"state"` // State of the scheduled event
-	EventID           string `mapstructure:"event-id"`
+	EventId           string `mapstructure:"event-id"`
 	NotBefore         string `mapstructure:"not-before"`                    // The earliest start time for the scheduled event
 	NotAfter          string `mapstructure:"not-after,omitempty"`           // The latest end time for the scheduled event
 	NotBeforeDeadline string `mapstructure:"not-before-deadline,omitempty"` // The deadline for starting the event

--- a/pkg/mock/scheduledevents/scheduledevents.go
+++ b/pkg/mock/scheduledevents/scheduledevents.go
@@ -71,7 +71,7 @@ func getMetadata() t.Event {
 	eventResp := t.Event{
 		Code:              se.EventCode,
 		Description:       descriptionPrefix + se.EventCode,
-		EventID:           md.EventID,
+		EventId:           md.EventId,
 		State:             se.EventState,
 		NotBefore:         b.Format(timeLayout),
 		NotAfter:          a.Format(timeLayout),

--- a/pkg/mock/scheduledevents/scheduledevents.go
+++ b/pkg/mock/scheduledevents/scheduledevents.go
@@ -71,7 +71,7 @@ func getMetadata() t.Event {
 	eventResp := t.Event{
 		Code:              se.EventCode,
 		Description:       descriptionPrefix + se.EventCode,
-		EventId:           md.EventId,
+		EventID:           md.EventID,
 		State:             se.EventState,
 		NotBefore:         b.Format(timeLayout),
 		NotAfter:          a.Format(timeLayout),

--- a/test/e2e/cmd/scheduledevents-test
+++ b/test/e2e/cmd/scheduledevents-test
@@ -143,13 +143,13 @@ test_scheduledevents_time_conversions $SCHEDEV_PID
 # validate flag/env precedence; can't override scheduled-events via config
 export AEMM_SCHEDULED_EVENTS_STATE="completed"
 export AEMM_SCHEDULED_EVENTS_CODE="instance-reboot"
-start_cmd=$(create_cmd $METADATA_VERSION scheduledevents --port $AEMM_PORT --state canceled)
+start_cmd=$(create_cmd $METADATA_VERSION se --port $AEMM_PORT --state canceled)
 $start_cmd &
 SCHEDEV_PID=$!
 test_scheduledevents_config_precedence $SCHEDEV_PID
 
 # paths for other subcommands should be disabled
-start_cmd=$(create_cmd $METADATA_VERSION scheduledevents --port $AEMM_PORT)
+start_cmd=$(create_cmd $METADATA_VERSION se --port $AEMM_PORT)
 $start_cmd &
 SCHEDEV_PID=$!
 test_scheduledevents_subcommand_paths_404 $SCHEDEV_PID "http://$HOSTNAME:$AEMM_PORT/latest/meta-data/spot/instance-action" "spot-instance-action"

--- a/test/e2e/cmd/spotitn-test
+++ b/test/e2e/cmd/spotitn-test
@@ -85,7 +85,7 @@ echo "==========================================================================
 echo "🥑 Starting spotitn integration tests $METADATA_VERSION"
 echo "======================================================================================================"
 
-start_cmd=$(create_cmd $METADATA_VERSION spotitn --port $AEMM_PORT)
+start_cmd=$(create_cmd $METADATA_VERSION spot --port $AEMM_PORT)
 $start_cmd &
 SPOTITN_PID=$!
 test_spotitn_paths $SPOTITN_PID
@@ -95,14 +95,14 @@ SPOTITN_PID=$!
 test_spotitn_ia_defaults $SPOTITN_PID
 
 # flag overrides
-start_cmd=$(create_cmd $METADATA_VERSION spotitn --port $AEMM_PORT -a $FLAG_OVERRIDDEN_INSTANCE_ACTION -t $FLAG_OVERRIDDEN_TERMINATION_TIME)
+start_cmd=$(create_cmd $METADATA_VERSION spot --port $AEMM_PORT -a $FLAG_OVERRIDDEN_INSTANCE_ACTION -t $FLAG_OVERRIDDEN_TERMINATION_TIME)
 $start_cmd &
 SPOTITN_PID=$!
 test_spotitn_ia_overrides $SPOTITN_PID $FLAG_OVERRIDDEN_INSTANCE_ACTION $FLAG_OVERRIDDEN_TERMINATION_TIME
 
 # flag + env overrides
 export AEMM_SPOT_ITN_INSTANCE_ACTION="stop"
-start_cmd=$(create_cmd $METADATA_VERSION spotitn --port $AEMM_PORT -t $FLAG_OVERRIDDEN_TERMINATION_TIME)
+start_cmd=$(create_cmd $METADATA_VERSION spot --port $AEMM_PORT -t $FLAG_OVERRIDDEN_TERMINATION_TIME)
 $start_cmd &
 SPOTITN_PID=$!
 test_spotitn_ia_overrides $SPOTITN_PID $ENV_OVERRIDDEN_INSTANCE_ACTION $FLAG_OVERRIDDEN_TERMINATION_TIME


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Updated command name for spot and aliases for both spot and scheduledevents
- If there's anything wrong with importing override config file (invalid json, can't be found, etc.), then application exits
- Corrected EventId capitalization in maintenance events

*Testing:*
- make test passes
- tried invalid json and non-existent json and application exits as expected
- updated command integration tests to use both command name and aliases
- updated ReadMe content with correct command aliases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
