### PR TITLE
include helm in the release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 - K8S_VERSION=1.15
 - K8S_VERSION=1.14
 
-script: test/helm/chart-test.sh -k $K8S_VERSION
+script: make helm-app-version-test && test/helm/chart-test.sh -k $K8S_VERSION
 
 matrix:
   include:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSION = $(shell git describe --tags --always --dirty)
+LATEST_TAG=$(shell git tag | tail -1)
 IMG ?= amazon/amazon-ec2-metadata-mock
 IMG_TAG ?= ${VERSION}
 IMG_W_TAG = ${IMG}:${IMG_TAG}
@@ -101,5 +102,8 @@ go-report-card-test:
 	${MAKEFILE_PATH}/test/go-report-card-test/run-report-card-test.sh
 
 test: unit-test e2e-test helm-e2e-test helm-app-version-test license-test go-report-card-test
+
+update-versions-for-release:
+	${MAKEFILE_PATH}/scripts/update-versions-for-release
 
 release: create-build-dir build-binaries build-docker-images push-docker-images generate-k8s-yaml gen-helm-chart-archives upload-resources-to-github

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ push-docker-images:
 version:
 	@echo ${VERSION}
 
+latest-tag:
+	@echo ${LATEST_TAG}
+
 image:
 	@echo ${IMG_W_TAG}
 
@@ -90,7 +93,7 @@ helm-app-version-test:
 	${MAKEFILE_PATH}/test/helm/helm-app-version-test.sh
 
 helm-tests:
-	helm-e2e-test helm-app-version-test
+	helm-app-version-test helm-e2e-test
 
 gen-helm-chart-archives:
 	${MAKEFILE_PATH}/scripts/generate-helm-chart-archives
@@ -101,7 +104,7 @@ license-test:
 go-report-card-test:
 	${MAKEFILE_PATH}/test/go-report-card-test/run-report-card-test.sh
 
-test: unit-test e2e-test helm-e2e-test helm-app-version-test license-test go-report-card-test
+test: unit-test e2e-test helm-app-version-test helm-e2e-test license-test go-report-card-test
 
 update-versions-for-release:
 	${MAKEFILE_PATH}/scripts/update-versions-for-release

--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,21 @@ helm-lint-test:
 helm-e2e-test:
 	${MAKEFILE_PATH}/test/helm/chart-test.sh
 
+helm-app-version-test:
+	${MAKEFILE_PATH}/test/helm/helm-app-version-test.sh
+
+helm-tests:
+	helm-e2e-test helm-app-version-test
+
+gen-helm-chart-archives:
+	${MAKEFILE_PATH}/scripts/generate-helm-chart-archives
+
 license-test:
 	${MAKEFILE_PATH}/test/license-test/run-license-test.sh
 
 go-report-card-test:
 	${MAKEFILE_PATH}/test/go-report-card-test/run-report-card-test.sh
 
-test: unit-test e2e-test helm-e2e-test license-test go-report-card-test
+test: unit-test e2e-test helm-e2e-test helm-app-version-test license-test go-report-card-test
 
-release: create-build-dir build-binaries build-docker-images push-docker-images generate-k8s-yaml upload-resources-to-github
+release: create-build-dir build-binaries build-docker-images push-docker-images generate-k8s-yaml gen-helm-chart-archives upload-resources-to-github

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ docker pull amazon/amazon-ec2-metadata-mock:v0.9.3
 docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.3
 ```
 
+### On Kubernetes
+#### Supported versions
+* Kubernetes >= 1.14
+
+#### Helm
+[See Helm README here.](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/helm/amazon-ec2-metadata-mock/README.md)
+
+#### kubectl
+kubectl apply -f https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.3/all-resources.yaml
+
 ## Starting AEMM
 Use `ec2-metadata-mock --help` to view examples and explanations of supported flags and commands:
 

--- a/README.md
+++ b/README.md
@@ -76,28 +76,28 @@ Download binary from the latest release:
 
 ### MacOS/Linux
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.3/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
 chmod +x ec2-metadata-mock
 ```
 
 ### ARM Linux
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.3/ec2-metadata-mock-linux-arm
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-linux-arm
 ```
 
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.3/ec2-metadata-mock-linux-arm64
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-linux-arm64
 ```
 
 ### Windows
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.3/ec2-metadata-mock-windows-amd64.exe
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-windows-amd64.exe
 ```
 
 ### Docker
 ```
-docker pull amazon/amazon-ec2-metadata-mock:v0.9.3
-docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.3
+docker pull amazon/amazon-ec2-metadata-mock:v0.9.4
+docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.4
 ```
 
 ### On Kubernetes
@@ -108,7 +108,7 @@ docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.3
 [See Helm README here.](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/helm/amazon-ec2-metadata-mock/README.md)
 
 #### kubectl
-kubectl apply -f https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.3/all-resources.yaml
+kubectl apply -f https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/all-resources.yaml
 
 ## Starting AEMM
 Use `ec2-metadata-mock --help` to view examples and explanations of supported flags and commands:

--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
 version: 0.5.1
-appVersion: v0.9.3
+appVersion: v0.9.4
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png
 sources:

--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
 version: 0.5.0
-appVersion: 0.9.3
+appVersion: v0.9.3
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png
 sources:

--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
-version: 0.5.0
+version: 0.5.1
 appVersion: v0.9.3
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -13,7 +13,7 @@ The helm chart can be installed from several sources. To install the chart with 
 1. Local chart archive: 
 Download the chart archive from the latest release and run 
 ```sh
-helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.0.tgz \
+helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.1.tgz \
   --namespace default
 ```
 

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -13,7 +13,7 @@ The helm chart can be installed from several sources. To install the chart with 
 1. Local chart archive: 
 Download the chart archive from the latest release and run 
 ```sh
-helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-1.0.0.tgz \
+helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.0.tgz \
   --namespace default
 ```
 
@@ -150,6 +150,12 @@ Alternatively, the same tests can be run using:
 make helm-lint-test # for linting only
 make helm-e2e-test  # for e2e tests, including linting
 ```
+
+### Versioning
+Increment the chart version when one or more files in the helm chart directory changes:
+* Increment patch version for readme changes
+* Increment minor version for backward compatible changes / new minor version of the app (appVersion)
+* Increment major version for incompatible changes / new major version of the app (appVersion)
 
 ## Configuration
 

--- a/helm/amazon-ec2-metadata-mock/values.yaml
+++ b/helm/amazon-ec2-metadata-mock/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: "amazon/amazon-ec2-metadata-mock"
-  tag: "v0.9.3"
+  tag: "v0.9.4"
   pullPolicy: "IfNotPresent"
 
 # nameOverride overrides the name of the helm chart

--- a/scripts/generate-helm-chart-archives
+++ b/scripts/generate-helm-chart-archives
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Script to generate the helm chart archives for charts in REPO/helm
+
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+MAKEFILEPATH=$SCRIPTPATH/../Makefile
+VERSION=$(make -s -f $MAKEFILEPATH version)
+HELM_CHART_PATH=$SCRIPTPATH/../helm
+BUILD_DIR=$SCRIPTPATH/../build/k8s-resources/$VERSION
+HELM_CHART_ARCHIVES_DIR=$BUILD_DIR/helm-chart-archives
+mkdir -p $HELM_CHART_ARCHIVES_DIR
+
+# $1: chart name, $2: chart version, $3: chart dir
+generate_chart_archive() {
+    cd $HELM_CHART_ARCHIVES_DIR && tar zcf $1-$2.tgz $3
+}
+
+main() {
+    for c in $HELM_CHART_PATH/*; do
+        chart_name=$(echo $c | tr '/' '\n' | tail -1)
+        if [ -d $c ]; then
+            chart_version=`sed -n 's/version: //p' $c/Chart.yaml`
+            app_version=`sed -n 's/appVersion: //p' $c/Chart.yaml`
+
+            generate_chart_archive $chart_name $chart_version $c
+        fi
+    done
+
+    echo -e "\nGenerated Helm chart archives in $HELM_CHART_ARCHIVES_DIR:"
+    for archive in $HELM_CHART_ARCHIVES_DIR/*; do
+        echo "    - $(echo $archive | tr '/' '\n' | tail -1)"
+    done
+}
+
+main $@

--- a/scripts/generate-k8s-yaml
+++ b/scripts/generate-k8s-yaml
@@ -58,8 +58,10 @@ $BUILD_DIR/helm template amazon-ec2-metadata-mock \
 
 # remove helm annotations from template
 for i in $INDV_RESOURCES_DIR/amazon-ec2-metadata-mock/templates/*; do
-  cat $i | grep -v 'helm.sh\|app.kubernetes.io/managed-by: Helm' > $BUILD_DIR/helm_annotations_removed.yaml
-  mv $BUILD_DIR/helm_annotations_removed.yaml $i
+    if [ -f $i ]; then # ignore helm tests
+        cat $i | grep -v 'helm.sh\|app.kubernetes.io/managed-by: Helm' > $BUILD_DIR/helm_annotations_removed.yaml
+        mv $BUILD_DIR/helm_annotations_removed.yaml $i
+    fi
 done
 
 cd $INDV_RESOURCES_DIR/amazon-ec2-metadata-mock/ && tar cvf $TAR_RESOURCES_FILE templates/*

--- a/scripts/update-versions-for-release
+++ b/scripts/update-versions-for-release
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# **Run this script and commit changes BEFORE creating a new release tag in Github**
 # Script to update versions in various files as part of release prep:
 ## AEMM version in:
 ### README.md
@@ -13,7 +14,8 @@ set -euo pipefail
 
 REPO_ROOT_PATH="$( cd "$(dirname "$0")"; cd ../; pwd -P )"
 MY_NAME=`basename "$0"`
-NEW_VERSION=$(git tag | tail -1)
+MAKEFILEPATH=$REPOPATH/Makefile
+NEW_VERSION=$(make -s -f $MAKEFILEPATH LATEST_TAG)
 OLD_VERSION=$(git tag | tail -2 | head -1)
 BUILD_DIR=$REPO_ROOT_PATH/build/$NEW_VERSION
 TMP_DIR=$BUILD_DIR/tmp-$MY_NAME

--- a/scripts/update-versions-for-release
+++ b/scripts/update-versions-for-release
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Script to update versions in various files as part of release prep:
+## AEMM version in:
+### README.md
+## * helm chart's values.yaml
+## * helm chart's Chart.yaml
+## helm chart version in:
+## * helm chart's Chart.yaml
+## * helm chart's README.md
+
+set -euo pipefail
+
+REPO_ROOT_PATH="$( cd "$(dirname "$0")"; cd ../; pwd -P )"
+MY_NAME=`basename "$0"`
+NEW_VERSION=$(git tag | tail -1)
+OLD_VERSION=$(git tag | tail -2 | head -1)
+BUILD_DIR=$REPO_ROOT_PATH/build/$NEW_VERSION
+TMP_DIR=$BUILD_DIR/tmp-$MY_NAME
+mkdir -p $TMP_DIR
+
+CHART=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/Chart.yaml
+CHART_README=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/README.md
+
+FILES=($REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/values.yaml  $REPO_ROOT_PATH/README.md  $CHART)
+
+FILES_CHANGED=()
+
+# $1: file 
+update_release_version() {
+    sed -i '' "s/$OLD_VERSION/$NEW_VERSION/g" $1
+    FILES_CHANGED+=($1)
+}
+
+update_versions_in_chart() {
+    # update versions, only if appVersion is not up-to-date
+    # we rely on helm chart linting to catch the case when the app version is updated but chart version is not incremented 
+    curr_app_version=$(sed -n 's/appVersion: //p' $CHART)
+    if [[ $curr_app_version == $NEW_VERSION ]]; then
+        echo "The chart is already updated. Not touching any versions in the chart dir."
+        return
+    fi
+    # update appVersion
+    sed -i '' 's/appVersion: $curr_app_version/appVersion: $NEW_VERSION/g' $CHART
+    FILES_CHANGED+=($CHART)
+
+    # update chart version
+    old_chart_version=$(sed -n 's/version: //p' $CHART)
+    old_major_v=$(echo $old_chart_version | tr '.' '\n' | head -1)
+    old_minor_v=$(echo $old_chart_version | tr '.' '\n' | head -2 | tail -1)
+    old_patch_v=$(echo $old_chart_version | tr '.' '\n' | tail -1)
+    new_patch_v=$(echo $(($old_patch_v + 1))) # increment patch version
+    new_chart_version=$(echo $old_major_v.$old_minor_v.$new_patch_v)
+
+    sed -i '' "s/version: $old_chart_version/version: $new_chart_version/g" $CHART
+    sed -i '' "s/amazon-ec2-metadata-mock-$old_chart_version.tgz/amazon-ec2-metadata-mock-$new_chart_version.tgz/g" $CHART_README
+    echo -e "\nUpdated chart version from $old_chart_version to $new_chart_version in files: \n$CHART\n$CHART_README"
+}
+
+main() {
+    echo "Attempting to update AEMM and Helm chart versions.\nOld AEMM version: $OLD_VERSION ---> New AEMM version: $NEW_VERSION"
+
+    for f in ${FILES[@]}; do
+        if [[ $f == $CHART ]]; then
+            update_versions_in_chart
+        else
+            update_release_version $f
+        fi
+    done
+
+    echo -e "\nUpdated latest release version in files: \n$(echo ${FILES_CHANGED[@]} | tr ' ' '\n')"
+}
+
+main $@

--- a/scripts/update-versions-for-release
+++ b/scripts/update-versions-for-release
@@ -14,8 +14,8 @@ set -euo pipefail
 
 REPO_ROOT_PATH="$( cd "$(dirname "$0")"; cd ../; pwd -P )"
 MY_NAME=`basename "$0"`
-MAKEFILEPATH=$REPOPATH/Makefile
-NEW_VERSION=$(make -s -f $MAKEFILEPATH LATEST_TAG)
+MAKEFILEPATH=$REPO_ROOT_PATH/Makefile
+NEW_VERSION=$(make -s -f $MAKEFILEPATH latest-tag)
 OLD_VERSION=$(git tag | tail -2 | head -1)
 BUILD_DIR=$REPO_ROOT_PATH/build/$NEW_VERSION
 TMP_DIR=$BUILD_DIR/tmp-$MY_NAME
@@ -43,7 +43,7 @@ update_versions_in_chart() {
         return
     fi
     # update appVersion
-    sed -i '' 's/appVersion: $curr_app_version/appVersion: $NEW_VERSION/g' $CHART
+    sed -i '' "s/appVersion: $curr_app_version/appVersion: $NEW_VERSION/g" $CHART
     FILES_CHANGED+=($CHART)
 
     # update chart version

--- a/scripts/upload-resources-to-github
+++ b/scripts/upload-resources-to-github
@@ -23,6 +23,9 @@ done
 
 ## Upload k8s yaml
 resourceFiles=($TAR_RESOURCES_FILE $AGG_RESOURCES_YAML)
+for archive in $HELM_ARCHIVES_DIR; do
+    resourceFiles+=($archive)
+done
 for resourceFile in "${resourceFiles[@]}"; do
     curl \
         -H "Authorization: token $GITHUB_TOKEN" \

--- a/test/helm/helm-app-version-test.sh
+++ b/test/helm/helm-app-version-test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 REPOPATH="$( cd "$(dirname "$0")"; cd ../../; pwd -P )"
 MAKEFILEPATH=$REPOPATH/Makefile
-RELEASE_VERSION=$(make -s -f $MAKEFILEPATH version)
+RELEASE_VERSION=$(make -s -f $MAKEFILEPATH LATEST_TAG)
 HELM_CHART_PATH=$REPOPATH/helm
 
 for c in $HELM_CHART_PATH/*; do

--- a/test/helm/helm-app-version-test.sh
+++ b/test/helm/helm-app-version-test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 REPOPATH="$( cd "$(dirname "$0")"; cd ../../; pwd -P )"
 MAKEFILEPATH=$REPOPATH/Makefile
-RELEASE_VERSION=$(make -s -f $MAKEFILEPATH LATEST_TAG)
+RELEASE_VERSION=$(make -s -f $MAKEFILEPATH latest-tag)
 HELM_CHART_PATH=$REPOPATH/helm
 
 for c in $HELM_CHART_PATH/*; do

--- a/test/helm/helm-app-version-test.sh
+++ b/test/helm/helm-app-version-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Script to test that all helm charts' Chart.yaml and values.yaml are updated to reflect the latest release
+# Exit with error when values.yaml is not updated with the current release version
+
+set -euo pipefail
+
+REPOPATH="$( cd "$(dirname "$0")"; cd ../../; pwd -P )"
+MAKEFILEPATH=$REPOPATH/Makefile
+RELEASE_VERSION=$(make -s -f $MAKEFILEPATH version)
+HELM_CHART_PATH=$REPOPATH/helm
+
+for c in $HELM_CHART_PATH/*; do
+    chart_name=$(echo $c | tr '/' '\n' | tail -1)
+    if [ -d $c ]; then
+
+        # verify AEMM version in Chart/yaml
+        # note: appVersion in Chart.yaml is informational only
+        app_version=$(sed -n 's/appVersion: //p' $c/Chart.yaml)
+        if [[ $app_version != $RELEASE_VERSION ]]; then
+            echo "Please update the appVersion in $chart_name helm chart's Chart.yaml and increment the chart version, if not already done. Expected version $RELEASE_VERSION, but got $app_version"
+        fi
+
+        # verify AEMM version in values.yaml in order to test the latest release
+        values_image_tag=$(sed -n 's/[^\s]tag: //p' $c/values.yaml | tr -d '""' | tr -d ' ')
+        if [[ $values_image_tag != $RELEASE_VERSION ]]; then
+            echo "Please update the release version in $chart_name helm chart's values.yaml, image.tag field and increment the chart version, if not already done. Expected version $RELEASE_VERSION, but got $values_image_tag"
+            exit 1
+        fi
+    fi
+done


### PR DESCRIPTION
*Description of changes:*
* add helm scripts for release - generation of helm chart archive
* modify release scripts to include helm
* add test for release version in helm to ensure we are testing against the latest version of AEMM when helm-e2e-test is run
* update appVersion from '0.9.3' to 'v0.9.3'
* add a script to be run manually to update the AEMM version and helm chart versions in various files
* release prep for v0.9.4 - this will be overwritten once this PR is merged.
* updated helm-app-version-test to use `git tag` instead of result from `git describe` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
