### PR TITLE
Correcting spot interrupt notice response

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Flags:
   -h, --help                      help for spot
   -a, --action string             action in the spot interruption notice (default: terminate)
                                   action can be one of the following: terminate,hibernate,stop
-  -t, --termination-time string   termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
+  -t, --time string               time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
   -c, --config-file string    config file for cli input parameters in json format (default: $HOME/aemm-config.json)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Usage:
 
 Examples:
   ec2-metadata-mock --mock-delay-sec 10	mocks all metadata paths
-  ec2-metadata-mock spot --instance-action terminate	mocks spot ITN only
+  ec2-metadata-mock spot --action terminate	mocks spot ITN only
 
 Available Commands:
   help            Help about any command
@@ -241,19 +241,19 @@ $ ec2-metadata-mock spot --help
 Mock EC2 Spot interruption notice
 
 Usage:
-  ec2-metadata-mock spot [--instance-action ACTION] [flags]
+  ec2-metadata-mock spot [--action ACTION] [flags]
 
 Aliases:
   spot, spotitn
 
 Examples:
   ec2-metadata-mock spot -h 	spot help
-  ec2-metadata-mock spot -d 5 --instance-action terminate		mocks spot interruption only
+  ec2-metadata-mock spot -d 5 --action terminate		mocks spot interruption only
 
 Flags:
   -h, --help                      help for spot
-  -a, --instance-action string    instance action in the spot interruption notice (default: terminate)
-                                  instance-action can be one of the following: terminate,hibernate,stop
+  -a, --action string             action in the spot interruption notice (default: terminate)
+                                  action can be one of the following: terminate,hibernate,stop
   -t, --termination-time string   termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
@@ -275,7 +275,7 @@ Send the request:
 ```
 $ curl localhost:1338/latest/meta-data/spot/instance-action
 {
-	"instance-action": "terminate",
+	"action": "terminate",
 	"time": "2020-04-24T17:11:44Z"
 }
 ```
@@ -319,7 +319,7 @@ Once the delay is complete, querying `spot` paths return expected results:
 $ curl localhost:1338/latest/meta-data/spot/instance-action
 
 {
-	"instance-action": "terminate",
+	"action": "terminate",
 	"time": "2020-04-24T17:19:32Z"
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,11 +11,11 @@ The tool can be configured in various ways:
 2. Env variables
     ```
     $ export AEMM_MOCK_DELAY_SEC=12
-    $ export AEMM_SPOT_ITN_INSTANCE_ACTION=stop
+    $ export AEMM_SPOT_ITN_ACTION=stop
     $ env | grep AEMM     // To list the tool's env variables
     ```
 
-    > NOTE the translation of config key `spot-itn.instance-action` to `AEMM_SPOT_ITN_INSTANCE_ACTION` env variable.
+    > NOTE the translation of config key `spot-itn.action` to `AEMM_SPOT_ITN_ACTION` env variable.
 
 3. Configuration file in JSON format at `path/to/config-overrides.json`
 ```
@@ -30,7 +30,7 @@ The tool can be configured in various ways:
     }
   },
   "spot-itn": {
-    "instance-action": "terminate",
+    "action": "terminate",
     "time": "2020-01-07T01:03:47Z"
   }
 }
@@ -64,7 +64,7 @@ $ cat $HOME/.ec2-metadata-mock/.aemm-config-used.json
     "port": "1338"
   },
   "spot-itn": {
-    "instance-action": "stop",
+    "action": "stop",
     "time": "2020-01-07T01:03:47Z"
   }
 }
@@ -90,13 +90,13 @@ Defaults in code:
     "mock-delay-sec": 0,
     "save-config-to-file": false,
     "spot-itn": {
-       "instance-action": "terminate"
+       "action": "terminate"
     }
 }
 
 Env variables:
 export AEMM_MOCK_DELAY_SEC=12
-export AEMM_SPOT_ITN_INSTANCE_ACTION=hibernate
+export AEMM_SPOT_ITN_ACTION=hibernate
 export AEMM_CONFIG_FILE=/path/to/my-custom-aemm-config.json
 
 Config File (at /path/to/my-custom-aemm-config.json):
@@ -106,7 +106,7 @@ Config File (at /path/to/my-custom-aemm-config.json):
          "port": "1550"
     },
     "spot-itn": {
-       "instance-action": "stop"
+       "action": "stop"
     }
 }
 
@@ -122,7 +122,7 @@ The resulting config will have the following values (non-overriden values are tr
     "mock-delay-sec": 8,                                        # from CLI flag
     "config-file": "/path/to/my-custom-aemm-config.json",       # from env
     "spot-itn": {
-        "instance-action": "hibernate"                          # from env
+        "action": "hibernate"                          # from env
    }
     "imdsv2": true,                                             # from custom config file at /path/to/my-custom-aemm-config.json
      "server": {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,19 +32,19 @@ $ ec2-metadata-mock spot --help
 Mock EC2 Spot interruption notice
 
 Usage:
-  ec2-metadata-mock spot [--instance-action ACTION] [flags]
+  ec2-metadata-mock spot [--action ACTION] [flags]
 
 Aliases:
   spot, spotitn
 
 Examples:
   ec2-metadata-mock spot -h 	spot help
-  ec2-metadata-mock spot -d 5 --instance-action terminate		mocks spot interruption only
+  ec2-metadata-mock spot -d 5 --action terminate		mocks spot interruption only
 
 Flags:
   -h, --help                      help for spot
-  -a, --instance-action string    instance action in the spot interruption notice (default: terminate)
-                                  instance-action can be one of the following: terminate,hibernate,stop
+  -a, --action string             action in the spot interruption notice (default: terminate)
+                                  action can be one of the following: terminate,hibernate,stop
   -t, --termination-time string   termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
@@ -56,14 +56,14 @@ Global Flags:
   -s, --save-config-to-file   whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
 ```
 
-1.) **Overriding `spot::instance-action` via CLI flag**:
+1.) **Overriding `spot::action` via CLI flag**:
 
 ```
 $ ec2-metadata-mock spot -a stop
 Initiating amazon-ec2-metadata-mock for EC2 Spot interruption notice on port 1338
 
 Flags:
-instance-action: stop
+action: stop
 
 Serving the following routes: ... (truncated for readability)
 ```
@@ -72,7 +72,7 @@ Send the request:
 ```
 $ curl localhost:1338/latest/meta-data/spot/instance-action
 {
-	"instance-action": "stop",
+	"action": "stop",
 	"time": "2020-04-24T17:11:44Z"
 }
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,7 +45,7 @@ Flags:
   -h, --help                      help for spot
   -a, --action string             action in the spot interruption notice (default: terminate)
                                   action can be one of the following: terminate,hibernate,stop
-  -t, --termination-time string   termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
+  -t, --time string               time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
   -c, --config-file string    config file for cli input parameters in json format (default: $HOME/aemm-config.json)

--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
-version: 0.5.1
+version: 0.5.2
 appVersion: v0.9.4
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -13,7 +13,7 @@ The helm chart can be installed from several sources. To install the chart with 
 1. Local chart archive: 
 Download the chart archive from the latest release and run 
 ```sh
-helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.1.tgz \
+helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.2.tgz \
   --namespace default
 ```
 
@@ -105,7 +105,7 @@ helm install amazon-ec2-metadata-mock ./helm/amazon-ec2-metadata-mock \
 
     curl http://localhost:1338/latest/meta-data/spot/instance-action
     {
-        "instance-action": "terminate",
+        "action": "terminate",
         "time": "2020-05-04T18:11:37Z"
     }
     ```
@@ -116,7 +116,7 @@ helm install amazon-ec2-metadata-mock ./helm/amazon-ec2-metadata-mock \
 
     curl http://$AMAZON_EC2_METADATA_MOCK_SERVICE_SERVICE_HOST:$AMAZON_EC2_METADATA_MOCK_SERVICE_SERVICE_PORT/latest/meta-data/spot/instance-action
     {
-        "instance-action": "terminate",
+        "action": "terminate",
         "time": "2020-05-04T18:11:37Z"
     }
     ```
@@ -126,7 +126,7 @@ helm install amazon-ec2-metadata-mock ./helm/amazon-ec2-metadata-mock \
 
     curl http://amazon-ec2-metadata-mock-service.default.svc.cluster.local:1338/latest/meta-data/spot/instance-action
     {
-        "instance-action": "terminate",
+        "action": "terminate",
         "time": "2020-05-04T18:11:37Z"
     }
     ```

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -48,7 +48,7 @@ helm install amazon-ec2-metadata-mock ./helm/amazon-ec2-metadata-mock \
 * Passing custom values to Helm via CLI arguments
 ```sh
 helm install amazon-ec2-metadata-mock ./helm/amazon-ec2-metadata-mock \
-  --namespace default --set aemm.spotItn.instanceAction="stop",aemm.mockDelaySec=120
+  --namespace default --set aemm.spotItn.action="stop",aemm.mockDelaySec=120
 ```
 
 * Passing a config file to AEMM
@@ -200,8 +200,8 @@ Parameter | Description | Default in Helm | Default AEMM configuration
 `aemm.server.hostname` | hostname to run AEMM on | `""`, in order to listen on all available interfaces e.g. ClusterIP | `0.0.0.0`
 `aemm.mockDelaySec` | mock delay in seconds, relative to the start time of AEMM | `0` | `0`
 `aemm.imdsv2` | if true, IMDSv2 only works | `false` | `false`, meaning both IMDSv1/v2 work 
-`aemm.spotItn.instanceAction` | instance action in the spot interruption notice | `""` | `terminate`
-`aemm.spotItn.terminationTime` | termination time in the spot interruption notice | `""` | HTTP request time + 2 minutes
+`aemm.spotItn.action` | action in the spot interruption notice | `""` | `terminate`
+`aemm.spotItn.time` | time in the spot interruption notice | `""` | HTTP request time + 2 minutes
 `aemm.scheduledEvents.code` | event code in the scheduled event | `""` | `system-reboot`
 `aemm.scheduledEvents.notAfter` | the latest end time for the scheduled event | `""` | Start time of AEMM  + 7 days
 `aemm.scheduledEvents.notBefore` | the earliest start time for the scheduled event | `""` | Start time of AEMM

--- a/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
@@ -103,11 +103,11 @@ spec:
         - name: AEMM_SCHEDULED_EVENTS_STATE
           value: {{ .Values.aemm.scheduledEvents.state | quote }}
         {{- end }}
-        {{- if .Values.aemm.spotItn.instanceAction }}
+        {{- if .Values.aemm.spotItn.action }}
         - name: AEMM_SPOT_ITN_ACTION
           value: {{ .Values.aemm.spotItn.action | quote }}
         {{- end }}
-        {{- if .Values.aemm.spotItn.terminationTime }}
-        - name: AEMM_SPOT_ITN_TERMINATION_TIME
-          value: {{ .Values.aemm.spotItn.terminationTime | quote }}
+        {{- if .Values.aemm.spotItn.time }}
+        - name: AEMM_SPOT_ITN_TIME
+          value: {{ .Values.aemm.spotItn.time | quote }}
         {{- end }}

--- a/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
@@ -104,8 +104,8 @@ spec:
           value: {{ .Values.aemm.scheduledEvents.state | quote }}
         {{- end }}
         {{- if .Values.aemm.spotItn.instanceAction }}
-        - name: AEMM_SPOT_ITN_INSTANCE_ACTION
-          value: {{ .Values.aemm.spotItn.instanceAction | quote }}
+        - name: AEMM_SPOT_ITN_ACTION
+          value: {{ .Values.aemm.spotItn.action | quote }}
         {{- end }}
         {{- if .Values.aemm.spotItn.terminationTime }}
         - name: AEMM_SPOT_ITN_TERMINATION_TIME

--- a/helm/amazon-ec2-metadata-mock/templates/tests/test-aemm-service.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/tests/test-aemm-service.yaml
@@ -11,7 +11,7 @@ metadata:
   name: "{{ .Release.Name }}-helm-e2e-test"
   annotations:
     "helm.sh/hook": "test"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "1" # create config-map first
 spec:
   restartPolicy: Never

--- a/helm/amazon-ec2-metadata-mock/values.yaml
+++ b/helm/amazon-ec2-metadata-mock/values.yaml
@@ -58,8 +58,8 @@ aemm:
   mockDelaySec: 0
   imdsv2: false
   spotItn:
-    instanceAction: ""
-    terminationTime: ""
+    action: ""
+    time: ""
   scheduledEvents:
     code: ""
     notAfter: ""

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -59,7 +59,7 @@ func NewCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               cmdutil.BinName + " <command> [arguments]",
 		SuggestFor:        []string{"mock", "ec2-mock", "ec2-metadata-mock"},
-		Example:           fmt.Sprintf("  %s --mock-delay-sec 10\tmocks all metadata paths\n  %s spotitn --action terminate\tmocks spot ITN only", cmdutil.BinName, cmdutil.BinName),
+		Example:           fmt.Sprintf("  %s --mock-delay-sec 10\tmocks all metadata paths\n  %s spot --action terminate\tmocks spot ITN only", cmdutil.BinName, cmdutil.BinName),
 		PersistentPreRunE: setupAndSaveConfig, // persistentPreRun runs before PreRun
 		PreRunE:           preRun,
 		Run:               run,

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -59,7 +59,7 @@ func NewCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               cmdutil.BinName + " <command> [arguments]",
 		SuggestFor:        []string{"mock", "ec2-mock", "ec2-metadata-mock"},
-		Example:           fmt.Sprintf("  %s --mock-delay-sec 10\tmocks all metadata paths\n  %s spotitn --instance-action terminate\tmocks spot ITN only", cmdutil.BinName, cmdutil.BinName),
+		Example:           fmt.Sprintf("  %s --mock-delay-sec 10\tmocks all metadata paths\n  %s spotitn --action terminate\tmocks spot ITN only", cmdutil.BinName, cmdutil.BinName),
 		PersistentPreRunE: setupAndSaveConfig, // persistentPreRun runs before PreRun
 		PreRunE:           preRun,
 		Run:               run,

--- a/pkg/cmd/spotitn/spotitn.go
+++ b/pkg/cmd/spotitn/spotitn.go
@@ -32,7 +32,7 @@ const (
 
 	// local flags
 	instanceActionFlagName  = "action"
-	terminationTimeFlagName = "termination-time"
+	terminationTimeFlagName = "time"
 
 	// instance actions
 	terminate = "terminate"
@@ -110,7 +110,7 @@ func ValidateLocalConfig() []string {
 		)
 	}
 
-	// validate termination-time, if override provided
+	// validate time, if override provided
 	if c.TerminationTime != "" {
 		if err := cmdutil.ValidateRFC3339TimeFormat(terminationTimeFlagName, c.TerminationTime); err != nil {
 			errStrings = append(errStrings, err.Error())

--- a/pkg/cmd/spotitn/spotitn.go
+++ b/pkg/cmd/spotitn/spotitn.go
@@ -31,7 +31,7 @@ const (
 	cfgPrefix = "spot-itn."
 
 	// local flags
-	instanceActionFlagName  = "instance-action"
+	instanceActionFlagName  = "action"
 	terminationTimeFlagName = "termination-time"
 
 	// instance actions
@@ -66,17 +66,17 @@ func initConfig() {
 
 func newCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "spot [--instance-action ACTION]",
+		Use:     "spot [--action ACTION]",
 		Aliases: []string{"spotitn"},
 		PreRunE: preRun,
-		Example: fmt.Sprintf("  %s spot -h \tspot help \n  %s spot -d 5 --instance-action terminate\t\tmocks spot interruption only", cmdutil.BinName, cmdutil.BinName),
+		Example: fmt.Sprintf("  %s spot -h \tspot help \n  %s spot -d 5 --action terminate\t\tmocks spot interruption only", cmdutil.BinName, cmdutil.BinName),
 		Run:     run,
 		Short:   "Mock EC2 Spot interruption notice",
 		Long:    "Mock EC2 Spot interruption notice",
 	}
 
 	// local flags
-	cmd.Flags().StringP(instanceActionFlagName, "a", "", "instance action in the spot interruption notice (default: terminate)\ninstance-action can be one of the following: "+strings.Join(validInstanceActions, ","))
+	cmd.Flags().StringP(instanceActionFlagName, "a", "", "action in the spot interruption notice (default: terminate)\naction can be one of the following: "+strings.Join(validInstanceActions, ","))
 	cmd.Flags().StringP(terminationTimeFlagName, "t", "", "termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)")
 
 	// bind local flags to config

--- a/pkg/cmd/spotitn/spotitn_test.go
+++ b/pkg/cmd/spotitn/spotitn_test.go
@@ -29,7 +29,7 @@ func TestNewCmdName(t *testing.T) {
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for spotitn command to be %s, but was %s", expected, actual))
 }
 func TestNewCmdLocalFlags(t *testing.T) {
-	expectedFlags := []string{"action", "termination-time"}
+	expectedFlags := []string{"action", "time"}
 
 	cmd := newCmd()
 	actualFlagSet := cmd.LocalFlags()

--- a/pkg/cmd/spotitn/spotitn_test.go
+++ b/pkg/cmd/spotitn/spotitn_test.go
@@ -29,7 +29,7 @@ func TestNewCmdName(t *testing.T) {
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for spotitn command to be %s, but was %s", expected, actual))
 }
 func TestNewCmdLocalFlags(t *testing.T) {
-	expectedFlags := []string{"instance-action", "termination-time"}
+	expectedFlags := []string{"action", "termination-time"}
 
 	cmd := newCmd()
 	actualFlagSet := cmd.LocalFlags()

--- a/pkg/mock/spotitn/config/config.go
+++ b/pkg/mock/spotitn/config/config.go
@@ -16,5 +16,5 @@ package config
 // Config represents the configuration for the mock
 type Config struct {
 	InstanceAction  string `mapstructure:"action"`
-	TerminationTime string `mapstructure:"termination-time"`
+	TerminationTime string `mapstructure:"time"`
 }

--- a/pkg/mock/spotitn/config/config.go
+++ b/pkg/mock/spotitn/config/config.go
@@ -15,6 +15,6 @@ package config
 
 // Config represents the configuration for the mock
 type Config struct {
-	InstanceAction  string `mapstructure:"instance-action"`
+	InstanceAction  string `mapstructure:"action"`
 	TerminationTime string `mapstructure:"termination-time"`
 }

--- a/pkg/mock/spotitn/internal/types/types.go
+++ b/pkg/mock/spotitn/internal/types/types.go
@@ -15,6 +15,6 @@ package types
 
 // InstanceActionResponse metadata structure for mock json response parsing
 type InstanceActionResponse struct {
-	InstanceAction string `json:"instance-action"`
-	Time           string `json:"time"`
+	Action string `json:"action"`
+	Time   string `json:"time"`
 }

--- a/pkg/mock/spotitn/spotitn.go
+++ b/pkg/mock/spotitn/spotitn.go
@@ -75,7 +75,7 @@ func Handler(res http.ResponseWriter, req *http.Request) {
 
 func getInstanceActionResponse(time string) t.InstanceActionResponse {
 	return t.InstanceActionResponse{
-		InstanceAction: c.SpotItnConfig.InstanceAction,
-		Time:           time,
+		Action: c.SpotItnConfig.InstanceAction,
+		Time:   time,
 	}
 }

--- a/test/e2e/cmd/spotitn-test
+++ b/test/e2e/cmd/spotitn-test
@@ -31,10 +31,10 @@ function test_spotitn_ia_defaults() {
   TOKEN=$(get_v2Token $MAX_TOKEN_TTL $AEMM_PORT)
 
   response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_IA_TEST_PATH)
-  actual_inst_action=$(get_value '"instance-action"' "$response")
+  actual_inst_action=$(get_value '"action"' "$response")
   actual_ia_time=$(get_value '"time"' "$response")
 
-  assert_value "$actual_inst_action" $SPOTITN_INSTANCE_ACTION_DEFAULT 'Default spotitn_ia::instance-action val'
+  assert_value "$actual_inst_action" $SPOTITN_INSTANCE_ACTION_DEFAULT 'Default spotitn_ia::action val'
   assert_format "$actual_ia_time" $SPOTITN_DATE_REGEX 'Default spotitn_ia::time format'
 
   actual_term_time=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_TT_TEST_PATH)
@@ -52,10 +52,10 @@ function test_spotitn_ia_overrides() {
   TOKEN=$(get_v2Token $MAX_TOKEN_TTL $AEMM_PORT)
 
   response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_IA_TEST_PATH)
-  actual_inst_action=$(get_value '"instance-action"' "$response")
+  actual_inst_action=$(get_value '"action"' "$response")
   actual_ia_time=$(get_value '"time"' "$response")
 
-  assert_value "$actual_inst_action" $expected_inst_action 'Override spotitn_ia::instance-action'
+  assert_value "$actual_inst_action" $expected_inst_action 'Override spotitn_ia::action'
   assert_value "$actual_ia_time" $expected_term_time 'Override spotitn_ia::time'
 
   actual_term_time=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_TT_TEST_PATH)
@@ -101,21 +101,21 @@ SPOTITN_PID=$!
 test_spotitn_ia_overrides $SPOTITN_PID $FLAG_OVERRIDDEN_INSTANCE_ACTION $FLAG_OVERRIDDEN_TERMINATION_TIME
 
 # flag + env overrides
-export AEMM_SPOT_ITN_INSTANCE_ACTION="stop"
+export AEMM_SPOT_ITN_ACTION="stop"
 start_cmd=$(create_cmd $METADATA_VERSION spot --port $AEMM_PORT -t $FLAG_OVERRIDDEN_TERMINATION_TIME)
 $start_cmd &
 SPOTITN_PID=$!
 test_spotitn_ia_overrides $SPOTITN_PID $ENV_OVERRIDDEN_INSTANCE_ACTION $FLAG_OVERRIDDEN_TERMINATION_TIME
 
 # env + config overrides
-export AEMM_SPOT_ITN_INSTANCE_ACTION="stop"
+export AEMM_SPOT_ITN_ACTION="stop"
 start_cmd=$(create_cmd $METADATA_VERSION spotitn --port $AEMM_PORT -c $TEST_CONFIG_FILE)
 $start_cmd &
 SPOTITN_PID=$!
 test_spotitn_ia_overrides $SPOTITN_PID $ENV_OVERRIDDEN_INSTANCE_ACTION $CONFIG_OVERRIDDEN_TERMINATION_TIME
 
 # flag + env + config overrides
-export AEMM_SPOT_ITN_INSTANCE_ACTION="stop"
+export AEMM_SPOT_ITN_ACTION="stop"
 start_cmd=$(create_cmd $METADATA_VERSION spotitn --port $AEMM_PORT -a $FLAG_OVERRIDDEN_INSTANCE_ACTION -c $TEST_CONFIG_FILE)
 $start_cmd &
 SPOTITN_PID=$!

--- a/test/e2e/cmd/spotitn-test
+++ b/test/e2e/cmd/spotitn-test
@@ -38,7 +38,7 @@ function test_spotitn_ia_defaults() {
   assert_format "$actual_ia_time" $SPOTITN_DATE_REGEX 'Default spotitn_ia::time format'
 
   actual_term_time=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_TT_TEST_PATH)
-  assert_value "$actual_term_time" "$actual_ia_time" 'Default spotitn::termination-time val'
+  assert_value "$actual_term_time" "$actual_ia_time" 'Default spotitn::time val'
 
   clean_up $pid
 }
@@ -59,7 +59,7 @@ function test_spotitn_ia_overrides() {
   assert_value "$actual_ia_time" $expected_term_time 'Override spotitn_ia::time'
 
   actual_term_time=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_TT_TEST_PATH)
-  assert_value "$actual_term_time" "$actual_ia_time" 'Override spotitn::termination-time val'
+  assert_value "$actual_term_time" "$actual_ia_time" 'Override spotitn::time val'
 
   clean_up $pid
 }

--- a/test/e2e/testdata/aemm-config-integ.json
+++ b/test/e2e/testdata/aemm-config-integ.json
@@ -9,7 +9,7 @@
     }
   },
   "spot-itn": {
-    "instance-action": "terminate",
+    "action": "terminate",
     "termination-time": "2020-01-07T01:03:47Z"
   }
 }

--- a/test/e2e/testdata/aemm-config-integ.json
+++ b/test/e2e/testdata/aemm-config-integ.json
@@ -10,6 +10,6 @@
   },
   "spot-itn": {
     "action": "terminate",
-    "termination-time": "2020-01-07T01:03:47Z"
+    "time": "2020-01-07T01:03:47Z"
   }
 }

--- a/test/e2e/testdata/output/aemm-config-used.json
+++ b/test/e2e/testdata/output/aemm-config-used.json
@@ -138,7 +138,7 @@
     "port": "1338"
   },
   "spot-itn": {
-    "instance-action": "terminate",
+    "action": "terminate",
     "termination-time": ""
   }
 }

--- a/test/e2e/testdata/output/aemm-config-used.json
+++ b/test/e2e/testdata/output/aemm-config-used.json
@@ -128,17 +128,17 @@
   "save-config-to-file": true,
   "scheduled-events": {
     "code": "system-reboot",
-    "not-after": "2020-05-07T21:15:10-05:00",
-    "not-before": "2020-04-30T21:15:10-05:00",
-    "not-before-deadline": "2020-05-09T21:15:10-05:00",
+    "not-after": "2020-06-15T15:55:49-05:00",
+    "not-before": "2020-06-08T15:55:49-05:00",
+    "not-before-deadline": "2020-06-17T15:55:49-05:00",
     "state": "active"
   },
   "server": {
-    "hostname": "localhost",
+    "hostname": "0.0.0.0",
     "port": "1338"
   },
   "spot-itn": {
     "action": "terminate",
-    "termination-time": ""
+    "time": ""
   }
 }


### PR DESCRIPTION
*Issue #, if available:* 
Spot interrupt notice used 'instance-action' as the key when it should be 'action': https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#instance-action-metadata

*Description of changes:*
* Updated spot itn response key from instance-action to action
* Updated flag for consistency
* Updated docs to reflect these changes
* Updated helm chart version

*Testing:*
* make clean && make test
* e2e tests verify the update flag and env var for spot action


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
