### PR TITLE
Fixing transient issues in integration tests

### DIFF
--- a/test/e2e/cmd/spotitn-test
+++ b/test/e2e/cmd/spotitn-test
@@ -38,7 +38,12 @@ function test_spotitn_ia_defaults() {
   assert_format "$actual_ia_time" $SPOTITN_DATE_REGEX 'Default spotitn_ia::time format'
 
   actual_term_time=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_TT_TEST_PATH)
-  assert_value "$actual_term_time" "$actual_ia_time" 'Default spotitn::time val'
+
+  actual_term_time_sec=$(convert_RFC3339_to_sec $actual_term_time)
+  actual_ia_time_sec=$(convert_RFC3339_to_sec $actual_ia_time)
+
+  # times should be within 5 second range
+  assert_value_within_range $actual_term_time_sec $actual_ia_time_sec 5
 
   clean_up $pid
 }
@@ -56,10 +61,18 @@ function test_spotitn_ia_overrides() {
   actual_ia_time=$(get_value '"time"' "$response")
 
   assert_value "$actual_inst_action" $expected_inst_action 'Override spotitn_ia::action'
-  assert_value "$actual_ia_time" $expected_term_time 'Override spotitn_ia::time'
+
+  actual_ia_time_sec=$(convert_RFC3339_to_sec $actual_ia_time)
+  expected_term_time_sec=$(convert_RFC3339_to_sec $expected_term_time)
+
+  # times should be within 5 second range
+  assert_value_within_range $actual_ia_time_sec $expected_term_time_sec 5
 
   actual_term_time=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOTITN_TT_TEST_PATH)
-  assert_value "$actual_term_time" "$actual_ia_time" 'Override spotitn::time val'
+  actual_term_time_sec=$(convert_RFC3339_to_sec $actual_term_time)
+
+  # times should be within 5 second range
+  assert_value_within_range $actual_term_time_sec $actual_ia_time_sec 5
 
   clean_up $pid
 }

--- a/test/e2e/run-tests
+++ b/test/e2e/run-tests
@@ -54,6 +54,24 @@ function assert_value() {
   fi
 }
 
+function assert_value_within_range() {
+  # assert actual == expected within specified range
+  # intended for time comparisons
+  actual=$1
+  expected=$2
+  range=$3
+  difference=$(($actual - $expected))
+  if [[ $difference -lt 0 ]]; then
+    difference=$(expr $difference \* -1)
+  fi
+  if [[ $difference -le $range ]]; then
+    echo "✅ Verified actual and expected are within range"
+  else
+    echo "❌ actual and expected are NOT within range"
+    EXIT_CODE_TO_RETURN=1
+  fi
+}
+
 function assert_not_equal() {
   # assert actual != expected
   if [[ $1 != $2 ]]; then
@@ -104,8 +122,21 @@ function create_cmd() {
   echo "$cmd"
 }
 
+function convert_RFC3339_to_sec() {
+  RFC3339_timestamp=$1
+  time_in_sec=""
+  os=$(uname)
+  if [[ "$os" == "Darwin" ]]; then
+    time_in_sec=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RFC3339_timestamp" +"%s")
+  elif [[ "$os" == "Linux" ]]; then
+    time_in_sec=$(date -d"$RFC3339_timestamp" +"%s")
+  fi
+  echo "$time_in_sec"
+}
+
 function clean_up() {
   kill $@ || :
+  sleep 1
   echo "======================================================================================================"
   echo "💀 Killed server 💀"
   echo "======================================================================================================"
@@ -148,13 +179,16 @@ export SPOTITN_DATE_REGEX
 export JSON_VALUE_EXTRACTION_REGEX
 export MAX_TOKEN_TTL
 export EXIT_CODE_TO_RETURN
+
 export -f health_check
 export -f assert_value
+export -f assert_value_within_range
 export -f assert_not_equal
 export -f assert_format
 export -f get_value
 export -f get_v2Token
 export -f create_cmd
+export -f convert_RFC3339_to_sec
 export -f clean_up
 
 trap "fail_and_clean_up" INT TERM ERR


### PR DESCRIPTION
*Issue #, if available:*
* TravisCi (and testing locally) sometimes error out on e2e-tests for a couple reasons:
1. after calling clean_up, the next test is kicked off too quickly resulting in 'address already in use'
2. when comparing timestamps, the number of seconds is off by 1

*Description of changes:*
1. added a sleep to clean_up after calling kill as a buffer before kicking off next test
2. instead of exact comparison, see if times are within specified range (using 5 seconds)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
