### PR TITLE
correcting more responses to align with metadata service

### DIFF
--- a/pkg/config/defaults/aemm-metadata-default-values.json
+++ b/pkg/config/defaults/aemm-metadata-default-values.json
@@ -108,6 +108,7 @@
       "iam-security-credentials": {
         "Code": "Success",
         "LastUpdated" : "2020-04-02T18:50:40Z",
+        "Type": "AWS-HMAC",
         "AccessKeyId" : "12345678901",
         "SecretAccessKey" : "v/12345678901",
         "Token" : "TEST92test48TEST+y6RpoTEST92test48TEST/8oWVAiBqTEsT5Ky7ty2tEStxC1T==",

--- a/pkg/mock/scheduledevents/scheduledevents.go
+++ b/pkg/mock/scheduledevents/scheduledevents.go
@@ -61,7 +61,7 @@ func Handler(res http.ResponseWriter, req *http.Request) {
 	server.FormatAndReturnJSONResponse(res, getMetadata())
 }
 
-func getMetadata() t.Event {
+func getMetadata() []t.Event {
 	md := c.Metadata.Values
 	se := c.SchEventsConfig
 
@@ -77,5 +77,6 @@ func getMetadata() t.Event {
 		NotAfter:          a.Format(timeLayout),
 		NotBeforeDeadline: bd.Format(timeLayout),
 	}
-	return eventResp
+	// supports 1 scheduled event for now
+	return []t.Event{eventResp}
 }

--- a/pkg/mock/static/types/types.go
+++ b/pkg/mock/static/types/types.go
@@ -15,21 +15,21 @@ package types
 
 // IamInformation metadata structure for mock json response parsing
 type IamInformation struct {
-	Code               string `json:"code"`
-	LastUpdated        string `json:"last-updated"`
-	InstanceProfileArn string `json:"instance-profile-arn"`
-	InstanceProfileId  string `json:"instance-profile-id"`
+	Code               string `json:"Code"`
+	LastUpdated        string `json:"LastUpdated"`
+	InstanceProfileArn string `json:"InstanceProfileArn"`
+	InstanceProfileId  string `json:"InstanceProfileId"`
 }
 
 // IamSecurityCredentials metadata structure for mock json response parsing
 type IamSecurityCredentials struct {
-	Code            string `json:"code"`
-	LastUpdated     string `json:"last-updated"`
-	Type            string `json:"type"`
-	AccessKeyId     string `json:"access-key-id"`
-	SecretAccessKey string `json:"secret-access-key"`
-	Token           string `json:"token"`
-	Expiration      string `json:"expiration"`
+	Code            string `json:"Code"`
+	LastUpdated     string `json:"LastUpdated"`
+	Type            string `json:"Type"`
+	AccessKeyId     string `json:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	Token           string `json:"Token"`
+	Expiration      string `json:"Expiration"`
 }
 
 // ElasticInferenceAccelerator metadata structure for mock json response parsing


### PR DESCRIPTION
*Issue #, if available:*
* Addressing inconsistencies with some metadata responses

*Description of changes:*
* Updated responses for the following paths:
  * iam/info --> first letter of keys are now capitalized
  * iam/security-credentials/baskinc-role --> first letter of keys are now capitalized
  * events/maintenance/scheduled --> returns an array of events

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
