### PR TITLE
changing scheduledevents cmd name to events

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
       * [Overrides](#overrides)
    * [Usage](#usage)
       * [Spot Interruption](#spot-interruption)
-      * [Scheduled Events](#scheduled-events)
+      * [Scheduled Events](#events)
       * [Instance Metadata Service Versions](#instance-metadata-service-versions)
       * [Static Metadata](#static-metadata)
    * [Troubleshooting](#troubleshooting)
@@ -127,8 +127,8 @@ Examples:
   ec2-metadata-mock spot --action terminate	mocks spot ITN only
 
 Available Commands:
+  events          Mock EC2 maintenance events
   help            Help about any command
-  scheduledevents Mock EC2 Scheduled Events
   spot            Mock EC2 Spot interruption notice
 
 Flags:
@@ -224,7 +224,7 @@ Defaults for AEMM configuration are sourced throughout code. Examples below:
 * **Metadata mock responses**
   * [aemm-metadata-default-values.json](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/pkg/config/defaults/aemm-metadata-default-values.json)
 * **Commands**
-  * [scheduledevents](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/pkg/cmd/scheduledevents/scheduledevents.go#L72) 
+  * [events](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/pkg/cmd/scheduledevents/scheduledevents.go#L72) 
 
 ## Overrides
 AEMM supports configuration from various sources including: cli flags, env variables, and config files. Details regarding
@@ -325,27 +325,27 @@ $ curl localhost:1338/latest/meta-data/spot/instance-action
 
 ```
 
-## Scheduled Events
-Similar to spot, the `scheduledevents` command, view the local flags using `scheduledevents --help`:
+## Events
+Similar to spot, the `events` command, view the local flags using `events --help`:
 
 ```
-$ ec2-metadata-mock scheduledevents --help
+$ ec2-metadata-mock events --help
 Mock EC2 Scheduled Events
 
 Usage:
-  ec2-metadata-mock scheduledevents [--code CODE] [--state STATE] [--not-after] [--not-before-deadline] [flags]
+  ec2-metadata-mock events [--code CODE] [--state STATE] [--not-after] [--not-before-deadline] [flags]
 
 Aliases:
-  scheduledevents, se, scheduled-events, scheduledEvents
+  events, se, scheduledevents
 
 Examples:
-  ec2-metadata-mock scheduledevents -h 	scheduledevents help
-  ec2-metadata-mock scheduledevents -o instance-stop --state active -d		mocks an active and upcoming scheduled event for instance stop with a deadline for the event start time
+  ec2-metadata-mock events -h 	events help
+  ec2-metadata-mock events -o instance-stop --state active -d		mocks an active and upcoming scheduled event for instance stop with a deadline for the event start time
 
 Flags:
   -o, --code string                  event code in the scheduled event (default: system-reboot)
                                      event-code can be one of the following: instance-reboot,system-reboot,system-maintenance,instance-retirement,instance-stop
-  -h, --help                         help for scheduledevents
+  -h, --help                         help for events
   -a, --not-after string             the latest end time for the scheduled event in RFC3339 format E.g. 2020-01-07T01:03:47Z default: application start time + 7 days in UTC))
   -b, --not-before string            the earliest start time for the scheduled event in RFC3339 format E.g. 2020-01-07T01:03:47Z (default: application start time in UTC)
   -l, --not-before-deadline string   the deadline for starting the event in RFC3339 format E.g. 2020-01-07T01:03:47Z (default: application start time + 9 days in UTC)
@@ -355,10 +355,10 @@ Flags:
 (Truncated Global Flags for readability)
 ```
 
-1.) **Starting AEMM with `scheduledevents`**: `scheduledevents` route available immediately and `spot` routes will no longer be available due to the implementation of Commands [detailed here](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/docs/usage.md):
+1.) **Starting AEMM with `events`**: `events` route available immediately and `spot` routes will no longer be available due to the implementation of Commands [detailed here](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/docs/usage.md):
 
 ```
-$ ec2-metadata-mock scheduledevents --code instance-reboot -a 2020-01-07T01:03:47Z  -b 2020-01-01T01:03:47Z -l 2020-01-10T01:03:47Z --state completed
+$ ec2-metadata-mock events --code instance-reboot -a 2020-01-07T01:03:47Z  -b 2020-01-01T01:03:47Z -l 2020-01-10T01:03:47Z --state completed
 Initiating ec2-metadata-mock for EC2 Scheduled Events on port 1338
 Serving the following routes: ... (truncated for readability)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,21 +3,21 @@ This page serves as documentation for AEMM's advanced use cases and behavior.
 
 
 ## Commands
-AEMM's supported commands (`spot`, `scheduledevents`) are viewed using `--help`:
+AEMM's supported commands (`spot`, `events`) are viewed using `--help`:
 ```
 $ ec2-metadata-mock --help
 
 ...
 Available Commands:
+  events          Mock EC2 maintenance events
   help            Help about any command
-  scheduledevents Mock EC2 Scheduled Events
   spot            Mock EC2 Spot interruption notice
 
 ...
 ```
 commands are designed as follows:
 * Run independently from other commands
-  * i.e. when AEMM is started with `scheduledevents` subcommand, `spot` routes will **NOT** be available and vice-versa 
+  * i.e. when AEMM is started with `events` subcommand, `spot` routes will **NOT** be available and vice-versa 
 * Local flag availability so that commands can be configured directly via CLI parameters
     * With validation checks
 * Contain additional `--help` documentation
@@ -77,27 +77,27 @@ $ curl localhost:1338/latest/meta-data/spot/instance-action
 }
 ```
 
-### Scheduled Events
-Similar to spot, the `scheduledevents` command, view the local flags using `scheduledevents --help`:
+### Events
+Similar to spot, the `events` command, view the local flags using `events --help`:
 
 ```
-$ ec2-metadata-mock scheduledevents --help
+$ ec2-metadata-mock events --help
 Mock EC2 Scheduled Events
 
 Usage:
-  ec2-metadata-mock scheduledevents [--code CODE] [--state STATE] [--not-after] [--not-before-deadline] [flags]
+  ec2-metadata-mock events [--code CODE] [--state STATE] [--not-after] [--not-before-deadline] [flags]
 
 Aliases:
-  scheduledevents, se
+  events, se, scheduledevents
 
 Examples:
-  ec2-metadata-mock scheduledevents -h 	scheduledevents help
-  ec2-metadata-mock scheduledevents -o instance-stop --state active -d		mocks an active and upcoming scheduled event for instance stop with a deadline for the event start time
+  ec2-metadata-mock events -h 	events help
+  ec2-metadata-mock events -o instance-stop --state active -d		mocks an active and upcoming scheduled event for instance stop with a deadline for the event start time
 
 Flags:
   -o, --code string                  event code in the scheduled event (default: system-reboot)
                                      event-code can be one of the following: instance-reboot,system-reboot,system-maintenance,instance-retirement,instance-stop
-  -h, --help                         help for scheduledevents
+  -h, --help                         help for events
   -a, --not-after string             the latest end time for the scheduled event in RFC3339 format E.g. 2020-01-07T01:03:47Z default: application start time + 7 days in UTC))
   -b, --not-before string            the earliest start time for the scheduled event in RFC3339 format E.g. 2020-01-07T01:03:47Z (default: application start time in UTC)
   -l, --not-before-deadline string   the deadline for starting the event in RFC3339 format E.g. 2020-01-07T01:03:47Z (default: application start time + 9 days in UTC)
@@ -107,10 +107,10 @@ Flags:
 (Truncated Global Flags for readability)
 ```
 
-1.) **Starting AEMM with `scheduledevents` invalid flag overrides**: as noted above, all commands have validation logic for overrides via CLI flags. If the user attempts to pass an invalid override value, then AEMM will panic, kill the server, and return an error message with what went wrong:
+1.) **Starting AEMM with `events` invalid flag overrides**: as noted above, all commands have validation logic for overrides via CLI flags. If the user attempts to pass an invalid override value, then AEMM will panic, kill the server, and return an error message with what went wrong:
 
 ```
-$ ec2-metadata-mock scheduledevents --code FOO
+$ ec2-metadata-mock events --code FOO
 
 panic: Fatal error while executing the root command: Invalid CLI input "FOO" for flag code. 
 Allowed value(s): instance-reboot,system-reboot,system-maintenance,instance-retirement,instance-stop.

--- a/pkg/cmd/cmdutil/cmdutil.go
+++ b/pkg/cmd/cmdutil/cmdutil.go
@@ -115,18 +115,18 @@ func getHandlerPairs(cmd *cobra.Command, config cfg.Config) []handlerPair {
 	}
 
 	isSpot := strings.Contains(cmd.Name(), "spot")
-	isSchedEvents := strings.Contains(cmd.Name(), "scheduledevents")
+	isSchedEvents := strings.Contains(cmd.Name(), "events")
 
 	subCommandHandlers := map[string][]handlerPair{
 		"spot": {{path: config.Metadata.Paths.SpotItn, handler: spotitn.Handler},
 			{path: config.Metadata.Paths.SpotItnTerminationTime, handler: spotitn.Handler}},
-		"scheduledevents": {{path: config.Metadata.Paths.ScheduledEvents, handler: scheduledevents.Handler}},
+		"events": {{path: config.Metadata.Paths.ScheduledEvents, handler: scheduledevents.Handler}},
 	}
 
 	if isSpot {
 		handlerPairs = append(handlerPairs, subCommandHandlers["spot"]...)
 	} else if isSchedEvents {
-		handlerPairs = append(handlerPairs, subCommandHandlers["scheduledevents"]...)
+		handlerPairs = append(handlerPairs, subCommandHandlers["events"]...)
 	} else {
 		// root registers all subcommands
 		for k := range subCommandHandlers {

--- a/pkg/cmd/root/root_test.go
+++ b/pkg/cmd/root/root_test.go
@@ -43,7 +43,7 @@ func TestNewCmdFlags(t *testing.T) {
 	h.ItemsMatch(t, expectedFlags, actualFlags)
 }
 func TestNewCmdHasSubcommands(t *testing.T) {
-	expSubcommandNames := []string{"spot", "scheduledevents"}
+	expSubcommandNames := []string{"spot", "events"}
 
 	cmd := NewCmd()
 	actSubcommands := cmd.Commands()

--- a/pkg/cmd/scheduledevents/scheduledevents.go
+++ b/pkg/cmd/scheduledevents/scheduledevents.go
@@ -90,13 +90,13 @@ func initConfig() {
 
 func newCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "scheduledevents [--code CODE] [--state STATE] [--not-after] [--not-before-deadline]",
-		Aliases: []string{"se"},
+		Use:     "events [--code CODE] [--state STATE] [--not-after] [--not-before-deadline]",
+		Aliases: []string{"se", "scheduledevents"},
 		PreRunE: preRun,
 		Example: fmt.Sprintf("  %s scheduledevents -h \tscheduledevents help \n  %s scheduledevents -o instance-stop --state active -d\t\tmocks an active and upcoming scheduled event for instance stop with a deadline for the event start time", cmdutil.BinName, cmdutil.BinName),
 		Run:     run,
-		Short:   "Mock EC2 Scheduled Events",
-		Long:    "Mock EC2 Scheduled Events",
+		Short:   "Mock EC2 maintenance events",
+		Long:    "Mock EC2 maintenance events",
 	}
 
 	// local flags

--- a/pkg/cmd/scheduledevents/scheduledevents_test.go
+++ b/pkg/cmd/scheduledevents/scheduledevents_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestNewCmdName(t *testing.T) {
-	expected := "scheduledevents"
+	expected := "events"
 	actual := newCmd().Name()
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for scheduledevents command to be %s, but was %s", expected, actual))
 }

--- a/test/e2e/cmd/scheduledevents-test
+++ b/test/e2e/cmd/scheduledevents-test
@@ -121,7 +121,7 @@ echo "==========================================================================
 echo "🥑 Starting scheduledevents integration tests $METADATA_VERSION"
 echo "======================================================================================================"
 
-start_cmd=$(create_cmd $METADATA_VERSION scheduledevents --port $AEMM_PORT)
+start_cmd=$(create_cmd $METADATA_VERSION events --port $AEMM_PORT)
 $start_cmd &
 SCHEDEV_PID=$!
 test_scheduledevents_paths $SCHEDEV_PID
@@ -130,7 +130,7 @@ $start_cmd &
 SCHEDEV_PID=$!
 test_scheduledevents_defaults $SCHEDEV_PID
 
-start_cmd=$(create_cmd $METADATA_VERSION scheduledevents --port $AEMM_PORT --code instance-stop --state canceled)
+start_cmd=$(create_cmd $METADATA_VERSION events --port $AEMM_PORT --code instance-stop --state canceled)
 $start_cmd &
 SCHEDEV_PID=$!
 test_scheduledevents_code_and_state $SCHEDEV_PID


### PR DESCRIPTION
**Issue #, if available:**
* typing 'scheduledevents' as a cmd is clunky and poor cx
* not all 'events' are scheduled; some can be historical
  * events/maintenance/history path will be supported in the future

**Description of changes:**
* update cmd name to 'events'
* update docs to reflect new cmd name
* keeping 'scheduledevents' as a supported alias
* using all aliases for 'events' in integration tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
