### PR TITLE
fixing elastic inference accelerator response

### DIFF
--- a/pkg/mock/static/static.go
+++ b/pkg/mock/static/static.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	supportedPaths = make(map[string]interface{})
-	response       interface{}
+	supportedPaths   = make(map[string]interface{})
+	response         interface{}
+	jsonTextResponse = map[string]bool{"/latest/meta-data/elastic-inference/associations/eia-bfa21c7904f64a82a21b9f4540169ce1": true}
 )
 
 // Handler processes http requests
@@ -39,11 +40,15 @@ func Handler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	switch response.(type) {
-	// static metadata values are either string or JSON
+	// static metadata values are either string or JSON EXCEPT FOR elastic-inference associations
 	case string:
 		server.FormatAndReturnTextResponse(res, response.(string))
 	default:
-		server.FormatAndReturnJSONResponse(res, response)
+		if jsonTextResponse[req.URL.Path] {
+			server.FormatAndReturnJSONTextResponse(res, response)
+		} else {
+			server.FormatAndReturnJSONResponse(res, response)
+		}
 	}
 }
 

--- a/pkg/server/httpserver.go
+++ b/pkg/server/httpserver.go
@@ -111,6 +111,19 @@ func FormatAndReturnTextResponse(res http.ResponseWriter, data string) {
 	return
 }
 
+// FormatAndReturnJSONTextResponse formats the given data into JSON and returns a plaintext response
+func FormatAndReturnJSONTextResponse(res http.ResponseWriter, data interface{}) {
+	res.Header().Set("Content-Type", "text/plain")
+	var err error
+	var metadataPrettyJSON []byte
+	if metadataPrettyJSON, err = json.Marshal(data); err != nil {
+		log.Fatalf("Error while attempting to format data %s for response: %s", data, err)
+	}
+	res.Write(metadataPrettyJSON)
+	log.Println("Returned JSON text/plain mock response successfully.")
+	return
+}
+
 // ReturnNotFoundResponse returns response with 404 Not Found
 func ReturnNotFoundResponse(w http.ResponseWriter) {
 	http.Error(w, notFoundResponse, http.StatusNotFound)


### PR DESCRIPTION
**Issue:**
* /latest/meta-data/elastic-inference/associations/eia-bfa21c7904f64a82a21b9f4540169ce1 path returned empty AND malformed response 

*Description of changes:*
* added functionality to correctly populate these nested structs
* added response type that formats to look like JSON but actually returns content type text/plain
* elastic inference accelerator path correctly returns the following:

`{"version_2018_04_12":{"elastic-inference-accelerator-id":"eia-bfa21c7904f64a82a21b9f4540169ce1","elastic-inference-accelerator-type":"eia1.medium"}}`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
