### PR TITLE
bumping app and chart versions for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,21 +33,6 @@ jobs:
       language: go
       go: 1.14.x
       script: make e2e-test
-    - name: Helm E2E tests for K8s v1.18
-      script: make helm-app-version-test && test/helm/chart-test.sh -k $K8S_VERSION
-      env: K8S_VERSION=1.18
-    - name: Helm E2E tests for K8s v1.17
-      script: make helm-app-version-test && test/helm/chart-test.sh -k $K8S_VERSION
-      env: K8S_VERSION=1.17
-    - name: Helm E2E tests for K8s v1.16
-      script: make helm-app-version-test && test/helm/chart-test.sh -k $K8S_VERSION
-      env: K8S_VERSION=1.16
-    - name: Helm E2E tests for K8s v1.15
-      script: make helm-app-version-test && test/helm/chart-test.sh -k $K8S_VERSION
-      env: K8S_VERSION=1.15
-    - name: Helm E2E tests for K8s v1.14
-      script: make helm-app-version-test && test/helm/chart-test.sh -k $K8S_VERSION
-      env: K8S_VERSION=1.14
     - name: Build Github release assets
       if: env(GITHUB_TOKEN) IS present
       script: make build-release-assets

--- a/README.md
+++ b/README.md
@@ -76,28 +76,28 @@ Download binary from the latest release:
 
 ### MacOS/Linux
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
 chmod +x ec2-metadata-mock
 ```
 
 ### ARM Linux
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-linux-arm
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-linux-arm
 ```
 
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-linux-arm64
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-linux-arm64
 ```
 
 ### Windows
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/ec2-metadata-mock-windows-amd64.exe
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-windows-amd64.exe
 ```
 
 ### Docker
 ```
-docker pull amazon/amazon-ec2-metadata-mock:v0.9.4
-docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.4
+docker pull amazon/amazon-ec2-metadata-mock:v0.9.5
+docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.5
 ```
 
 ### On Kubernetes
@@ -108,7 +108,7 @@ docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.4
 [See Helm README here.](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/helm/amazon-ec2-metadata-mock/README.md)
 
 #### kubectl
-kubectl apply -f https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.4/all-resources.yaml
+kubectl apply -f https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/all-resources.yaml
 
 ## Starting AEMM
 Use `ec2-metadata-mock --help` to view examples and explanations of supported flags and commands:

--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
-version: 0.5.3
-appVersion: v0.9.4
+version: 0.5.4
+appVersion: v0.9.5
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png
 sources:

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -13,7 +13,7 @@ The helm chart can be installed from several sources. To install the chart with 
 1. Local chart archive: 
 Download the chart archive from the latest release and run 
 ```sh
-helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.2.tgz \
+helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.4.tgz \
   --namespace default
 ```
 

--- a/helm/amazon-ec2-metadata-mock/values.yaml
+++ b/helm/amazon-ec2-metadata-mock/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: "amazon/amazon-ec2-metadata-mock"
-  tag: "v0.9.4"
+  tag: "v0.9.5"
   pullPolicy: "IfNotPresent"
 
 # nameOverride overrides the name of the helm chart


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- updating app and chart versions for v0.9.5 release
- removed e2e helm tests in travis.yml due to race condition of testing versions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
