### PR TITLE
bump versions for release and fix helm test

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,28 +76,28 @@ Download binary from the latest release:
 
 ### MacOS/Linux
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.6/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
 chmod +x ec2-metadata-mock
 ```
 
 ### ARM Linux
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-linux-arm
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.6/ec2-metadata-mock-linux-arm
 ```
 
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-linux-arm64
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.6/ec2-metadata-mock-linux-arm64
 ```
 
 ### Windows
 ```
-curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.5/ec2-metadata-mock-windows-amd64.exe
+curl -Lo ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v0.9.6/ec2-metadata-mock-windows-amd64.exe
 ```
 
 ### Docker
 ```
-docker pull amazon/amazon-ec2-metadata-mock:v0.9.5
-docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.5
+docker pull amazon/amazon-ec2-metadata-mock:v0.9.6
+docker run -it --rm -p 1338:1338 amazon/amazon-ec2-metadata-mock:v0.9.6
 ```
 
 ### On Kubernetes

--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
-version: 0.5.4
-appVersion: v0.9.5
+version: 0.5.5
+appVersion: v0.9.6
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png
 sources:

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -13,7 +13,7 @@ The helm chart can be installed from several sources. To install the chart with 
 1. Local chart archive: 
 Download the chart archive from the latest release and run 
 ```sh
-helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.4.tgz \
+helm install amazon-ec2-metadata-mock amazon-ec2-metadata-mock-0.5.5.tgz \
   --namespace default
 ```
 

--- a/helm/amazon-ec2-metadata-mock/templates/tests/test-config-map.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/tests/test-config-map.yaml
@@ -14,6 +14,6 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   {{ .Values.configMapFileName }}: |
-    spot-itn:
-      termination-time: "1994-05-15T00:00:00Z"
+    spot:
+      time: "1994-05-15T00:00:00Z"
 {{- end }}

--- a/helm/amazon-ec2-metadata-mock/values.yaml
+++ b/helm/amazon-ec2-metadata-mock/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: "amazon/amazon-ec2-metadata-mock"
-  tag: "v0.9.5"
+  tag: "v0.9.6"
   pullPolicy: "IfNotPresent"
 
 # nameOverride overrides the name of the helm chart


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* bumping app and helm chart versions for v0.9.6 release
* fixed helm test now that it's testing against updated AEMM
  * this is bug that should be addressed when fixing race condition in helm e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
