### PR TITLE
do not generate helm tests in plain k8s resource files

### DIFF
--- a/scripts/generate-k8s-yaml
+++ b/scripts/generate-k8s-yaml
@@ -44,6 +44,7 @@ rm -rf $BUILD_DIR/$PLATFORM-amd64
 chmod +x $BUILD_DIR/helm
 
 $BUILD_DIR/helm template amazon-ec2-metadata-mock \
+    --no-hooks \
     --namespace $NAMESPACE \
     $SCRIPTPATH/../helm/amazon-ec2-metadata-mock/ > $AGG_RESOURCES_YAML
 
@@ -52,6 +53,7 @@ cat $AGG_RESOURCES_YAML | grep -v 'helm.sh\|app.kubernetes.io/managed-by: Helm' 
 mv $BUILD_DIR/helm_annotations_removed.yaml $AGG_RESOURCES_YAML
 
 $BUILD_DIR/helm template amazon-ec2-metadata-mock \
+    --no-hooks \
     --namespace $NAMESPACE \
     --output-dir $INDV_RESOURCES_DIR/ \
     $SCRIPTPATH/../helm/amazon-ec2-metadata-mock/
@@ -70,3 +72,4 @@ cd $SCRIPTPATH
 echo "Generated amazon-ec2-metadata-mock kubernetes yaml resources files in:"
 echo "    - $AGG_RESOURCES_YAML"
 echo "    - $TAR_RESOURCES_FILE"
+


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The plain resource files generated from the helm chart included the helm e2e resources as well. 
This PR removes those resources by adding the `--no-hooks` flag to the `helm template` executions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
