### PR TITLE
Fixing release targets for updated release scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ jobs:
     - stage: Docker Release
       name: Docker release
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKERHUB_TOKEN) IS present
-      script: make push-docker-images && make sync-readme-to-dockerhub
+      script: make release-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,40 +4,46 @@ language: minimal
 services:
 - docker
 
-env:
-- K8S_VERSION=1.18
-- K8S_VERSION=1.17
-- K8S_VERSION=1.16
-- K8S_VERSION=1.15
-- K8S_VERSION=1.14
+stages:
+- Build and Test
+- Github Release
+- Docker Release
 
-matrix:
+jobs:
   include:
-    - stage: Test
+    - stage: Build and Test
+      name: Build
       language: go
-      go: "1.14.x"
+      go: 1.14.x
+      script: make build
+    - name: Unit tests
+      language: go
+      go: 1.14.x
       script: make unit-test
-      env: GO111MODULE=on
-    - stage: Test
-      script: test/go-report-card-test/run-report-card-test.sh
-      env: GO_REPORT_CARD=true
-    - stage: Test
+    - name: Go report card test
+      script: make go-report-card-test
+    - name: Readme length validator
       script: make validate-readme
-      env: VALIDATE_README=true
-    - stage: Test
+    - name: License test
       if: type = push AND env(GITHUB_TOKEN) IS present
-      script: test/license-test/run-license-test.sh
-      env: LICENSE_TEST=true
-    - stage: Test
+      script: make license-test
+    - name: Helm lint test
+      script: make helm-lint-test
+    - name: AEMM E2E tests
       language: go
-      go: "1.14.x"
+      go: 1.14.x
       script: make e2e-test
-      env: E2E_TEST=true GO111MODULE=on
-    - stage: Deploy
-      if: type = push AND env(DOCKERHUB_USERNAME) IS present
-      script: make sync-readme-to-dockerhub
-      env: SYNC_README_TO_DOCKERHUB=true
-    - stage: Deploy
-      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKERHUB_USERNAME) IS present
+    - name: Build Github release assets
+      if: env(GITHUB_TOKEN) IS present
+      script: make build-release-assets
+    - name: Build Docker images
+      if: env(DOCKERHUB_TOKEN) IS present
+      script: make build-docker-images
+    - stage: Github Release
+      name: Github release
+      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
       script: make release
-      env: RELEASE_ASSETS=true
+    - stage: Docker Release
+      name: Docker release
+      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKERHUB_TOKEN) IS present
+      script: make push-docker-images && make sync-readme-to-dockerhub

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,13 @@ jobs:
       go: 1.14.x
       script: make e2e-test
     - name: Build Github release assets
-      if: env(GITHUB_TOKEN) IS present
       script: make build-release-assets
     - name: Build Docker images
-      if: env(DOCKERHUB_TOKEN) IS present
       script: make build-docker-images
     - stage: Github Release
       name: Github release
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
-      script: make release
+      script: make release-github
     - stage: Docker Release
       name: Docker release
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKERHUB_TOKEN) IS present

--- a/Makefile
+++ b/Makefile
@@ -16,25 +16,96 @@ METADATA_DEFAULTS_FILE=${MAKEFILE_PATH}/pkg/config/defaults/aemm-metadata-defaul
 ENCODED_METADATA_DEFAULTS=$(shell cat ${METADATA_DEFAULTS_FILE} | base64 | tr -d \\n)
 DEFAULT_VALUES_VAR=github.com/aws/amazon-ec2-metadata-mock/pkg/config/defaults.encodedDefaultValues
 
+version:
+	@echo ${VERSION}
+
+latest-tag:
+	@echo ${LATEST_TAG}
+
+image:
+	@echo ${IMG_W_TAG}
+
 create-build-dir:
 	mkdir -p ${BUILD_DIR_PATH}
 
 clean:
 	rm -rf ${BUILD_DIR_PATH}
 
-fmt:
-	goimports -w ./
-
 compile:
 	@echo ${MAKEFILE_PATH}
 	go build -a -tags aemm${GOOS} -ldflags '-X "${DEFAULT_VALUES_VAR}=${ENCODED_METADATA_DEFAULTS}"' -o ${BUILD_DIR_PATH}/${BINARY_NAME} ${MAKEFILE_PATH}/cmd/amazon-ec2-metadata-mock.go
 
+validate-json:
+	${MAKEFILE_PATH}/test/json-validator
+
 build: create-build-dir validate-json compile
 
-build-and-test: build test
+unit-test: create-build-dir
+	go test ${MAKEFILE_PATH}/... -v -coverprofile=coverage.txt -covermode=atomic -outputdir=${BUILD_DIR_PATH}
+
+validate-readme:
+	${MAKEFILE_PATH}/test/readme-validator
+
+e2e-test: build
+	${MAKEFILE_PATH}/test/e2e/run-tests
+
+helm-lint-test:
+	${MAKEFILE_PATH}/test/helm/chart-test.sh -l
+
+helm-app-version-test:
+	${MAKEFILE_PATH}/test/helm/helm-app-version-test.sh
+
+helm-e2e-test:
+	${MAKEFILE_PATH}/test/helm/chart-test.sh
+
+license-test:
+	${MAKEFILE_PATH}/test/license-test/run-license-test.sh
+
+go-report-card-test:
+	${MAKEFILE_PATH}/test/go-report-card-test/run-report-card-test.sh
+
+test: unit-test e2e-test helm-app-version-test helm-e2e-test license-test go-report-card-test
 
 build-binaries:
 	${MAKEFILE_PATH}/scripts/build-binaries -d -p ${SUPPORTED_PLATFORMS} -v ${VERSION}
+
+generate-k8s-yaml:
+	${MAKEFILE_PATH}/scripts/generate-k8s-yaml
+
+gen-helm-chart-archives:
+	${MAKEFILE_PATH}/scripts/generate-helm-chart-archives
+
+upload-resources-to-github:
+	${MAKEFILE_PATH}/scripts/upload-resources-to-github
+
+build-release-assets: create-build-dir build-binaries generate-k8s-yaml gen-helm-chart-archives
+
+release: upload-resources-to-github
+
+build-docker-images:
+	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION}
+
+push-docker-images:
+	@echo ${DOCKERHUB_TOKEN} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
+	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION} -m
+
+sync-readme-to-dockerhub:
+	${MAKEFILE_PATH}/scripts/sync-readme-to-dockerhub
+
+release-docker: build-docker-images push-docker-images sync-readme-to-dockerhub
+
+
+# Targets intended for local use 
+fmt:
+	goimports -w ./
+
+build-and-test: build test
+
+update-versions-for-release:
+	${MAKEFILE_PATH}/scripts/update-versions-for-release
+
+helm-tests:
+	helm-app-version-test helm-e2e-test
 
 docker-build:
 	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${GOOS}/${GOARCH} -r ${IMG} -v ${VERSION}
@@ -45,68 +116,3 @@ docker-run:
 docker-push:
 	@echo ${DOCKERHUB_TOKEN} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
 	docker push ${IMG_W_TAG}
-
-build-docker-images:
-	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION}
-
-push-docker-images:
-	@echo ${DOCKERHUB_TOKEN} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
-	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION} -m
-
-version:
-	@echo ${VERSION}
-
-latest-tag:
-	@echo ${LATEST_TAG}
-
-image:
-	@echo ${IMG_W_TAG}
-
-upload-resources-to-github:
-	${MAKEFILE_PATH}/scripts/upload-resources-to-github
-
-generate-k8s-yaml:
-	${MAKEFILE_PATH}/scripts/generate-k8s-yaml
-
-sync-readme-to-dockerhub:
-	${MAKEFILE_PATH}/scripts/sync-readme-to-dockerhub
-
-unit-test: create-build-dir
-	go test ${MAKEFILE_PATH}/... -v -coverprofile=coverage.txt -covermode=atomic -outputdir=${BUILD_DIR_PATH}
-
-e2e-test: build
-	${MAKEFILE_PATH}/test/e2e/run-tests
-
-validate-json:
-	${MAKEFILE_PATH}/test/json-validator
-
-validate-readme:
-	${MAKEFILE_PATH}/test/readme-validator
-
-helm-lint-test:
-	${MAKEFILE_PATH}/test/helm/chart-test.sh -l
-
-helm-e2e-test:
-	${MAKEFILE_PATH}/test/helm/chart-test.sh
-
-helm-app-version-test:
-	${MAKEFILE_PATH}/test/helm/helm-app-version-test.sh
-
-helm-tests:
-	helm-app-version-test helm-e2e-test
-
-gen-helm-chart-archives:
-	${MAKEFILE_PATH}/scripts/generate-helm-chart-archives
-
-license-test:
-	${MAKEFILE_PATH}/test/license-test/run-license-test.sh
-
-go-report-card-test:
-	${MAKEFILE_PATH}/test/go-report-card-test/run-report-card-test.sh
-
-test: unit-test e2e-test helm-app-version-test helm-e2e-test license-test go-report-card-test
-
-update-versions-for-release:
-	${MAKEFILE_PATH}/scripts/update-versions-for-release
-
-release: create-build-dir build-binaries build-docker-images push-docker-images generate-k8s-yaml gen-helm-chart-archives upload-resources-to-github

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ upload-resources-to-github:
 
 build-release-assets: create-build-dir build-binaries generate-k8s-yaml gen-helm-chart-archives
 
-release: upload-resources-to-github
+release: build-release-assets upload-resources-to-github
 
 build-docker-images:
 	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION}

--- a/scripts/upload-resources-to-github
+++ b/scripts/upload-resources-to-github
@@ -1,38 +1,86 @@
 #!/bin/bash
 set -euo pipefail
 
+# Script to upload release assets to Github.  
+# This script cleans up after itself in cases of parital failures. i.e. either all assets are uploaded or none
+
+
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 VERSION=$(make -s -f $SCRIPTPATH/../Makefile version)
 BUILD_DIR=$SCRIPTPATH/../build/k8s-resources/$VERSION
-INDV_RESOURCES_DIR=$BUILD_DIR/individual-resources
-TAR_RESOURCES_FILE=$BUILD_DIR/individual-resources.tar
-AGG_RESOURCES_YAML=$BUILD_DIR/all-resources.yaml
+BINARY_DIR=$SCRIPTPATH/../build/bin
+INDV_K8S_RESOURCES=$BUILD_DIR/individual-resources.tar
+AGG_K8S_RESOURCES=$BUILD_DIR/all-resources.yaml
 HELM_ARCHIVES_DIR=$BUILD_DIR/helm-chart-archives
 
 RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
     https://api.github.com/repos/aws/amazon-ec2-metadata-mock/releases | \
     jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
 
-for binary in $SCRIPTPATH/../build/bin/*; do
-    echo "Uploading $binary"
-    curl \
-        -H "Authorization: token $GITHUB_TOKEN" \
-        -H "Content-Type: $(file -b --mime-type $binary)" \
-        --data-binary @$binary \
-        "https://uploads.github.com/repos/aws/amazon-ec2-metadata-mock/releases/$RELEASE_ID/assets?name=$(basename $binary)"
-done
+export TERM="xterm"
+RED=$(tput setaf 1)
+RESET_FMT=$(tput sgr 0)
 
+ASSET_IDS_UPLOADED=()
 
-## Upload k8s resources
-resourceFiles=($TAR_RESOURCES_FILE $AGG_RESOURCES_YAML)
-for archive in $HELM_ARCHIVES_DIR/*; do
-    resourceFiles+=($archive)
-done
-for resourceFile in "${resourceFiles[@]}"; do
-    echo "Uploading $resourceFile"
-    curl \
+trap 'handle_errors_and_cleanup $?' EXIT
+
+handle_errors_and_cleanup() {
+    if [ $1 -eq "0" ]; then
+        exit 0
+    fi
+
+    if [[ ${#ASSET_IDS_UPLOADED[@]} -ne 0 ]]; then
+        echo -e "\nCleaning up assets uploaded in the current execution of the script"
+        for asset_id in $ASSET_IDS_UPLOADED; do
+            echo "Deleting asset $asset_id"
+            curl -X DELETE \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/aws/amazon-ec2-metadata-mock/releases/assets/$asset_id"
+        done
+        exit $1
+    fi
+}
+
+gather_assets_to_upload() {
+    local resources=($INDV_K8S_RESOURCES $AGG_K8S_RESOURCES)
+    for archive in $HELM_ARCHIVES_DIR/*; do
+        resources+=($archive)
+    done
+
+    for binary in $BINARY_DIR/*; do
+        resources+=($binary)
+    done
+    echo ${resources[@]}
+}
+
+# $1: absolute path to asset
+upload_asset() {
+    resp=$(curl --write-out %{http_code} --silent \
         -H "Authorization: token $GITHUB_TOKEN" \
-        -H "Content-Type: $(file -b --mime-type $resourceFile)" \
-        --data-binary @$resourceFile \
-        "https://uploads.github.com/repos/aws/amazon-ec2-metadata-mock/releases/$RELEASE_ID/assets?name=$(basename $resourceFile)"
+        -H "Content-Type: $(file -b --mime-type $1)" \
+        --data-binary @$1 \
+        "https://uploads.github.com/repos/aws/amazon-ec2-metadata-mock/releases/$RELEASE_ID/assets?name=$(basename $1)")
+
+    response_code=$(echo $resp | sed 's/\(.*\)}//')
+    response_content=$(echo $resp | sed "s/$response_code//")
+
+    # HTTP success code expected - 201 Created
+    if [[ $response_code -eq 201 ]]; then
+        asset_id=$(echo $response_content | jq '.id')
+        ASSET_IDS_UPLOADED+=($asset_id)
+        echo "Created asset ID $asset_id successfully"
+    else
+        echo -e "❌ ${RED}Upload failed with response code $response_code and message \n$response_content${RESET_FMT} ❌"
+        exit 1
+    fi
+}
+
+ASSETS=$(gather_assets_to_upload)
+COUNT=1
+echo -e "\nUploading release assets for release id '$RELEASE_ID' to Github"
+for asset in $ASSETS; do
+    name=$(echo $asset | tr '/' '\n' | tail -1)
+    echo -e "\n  $((COUNT++)). $name"
+    upload_asset $asset
 done


### PR DESCRIPTION
*Issue #, if available:*
* No issue #
* **issue:** when trying to execute release targets with improvements (#34) , `Github Release` and `Docker Release` jobs would fail
  * *ex:* https://travis-ci.org/github/aws/amazon-ec2-metadata-mock/jobs/699105736
  * *root cause:* Building of assets/artifacts was happening in a separate job which for travis means a separate VM; therefore, the release jobs would not have access to or be able to locate the assets

*Description of changes:*
* Reverted (#41 ) which brings back release improvements (#34) **minus** the helm e2e tests as there is a separate issue with versioning
* Updated `make release` to include `build-release-assets`
* Updated `Docker Release` to execute `make release-docker`

*Testing:*
* Created a release on my fork which executed release targets with my changes: https://travis-ci.org/github/brycahta/amazon-ec2-metadata-mock/builds/700971392


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
