### PR TITLE
Imdsv2 fixn

### DIFF
--- a/pkg/mock/imdsv2/tokengenerator.go
+++ b/pkg/mock/imdsv2/tokengenerator.go
@@ -42,6 +42,7 @@ type v2Token struct {
 
 // GenerateToken returns a token with the specified TTL used for IMDSv2 requests
 func GenerateToken(res http.ResponseWriter, req *http.Request) {
+	log.Printf("GenerateToken Received request: %v", req)
 	// only valid with PUT
 	if req.Method != http.MethodPut {
 		return

--- a/pkg/mock/imdsv2/tokengenerator.go
+++ b/pkg/mock/imdsv2/tokengenerator.go
@@ -70,6 +70,7 @@ func GenerateToken(res http.ResponseWriter, req *http.Request) {
 		CreatedAt: time.Now(),
 	}
 	generatedTokens[token.Value] = token
+	res.Header().Set(tokenTTLHeader, strconv.Itoa(token.TTL))
 	server.FormatAndReturnTextResponse(res, token.Value)
 }
 

--- a/pkg/mock/imdsv2/tokenvalidator.go
+++ b/pkg/mock/imdsv2/tokenvalidator.go
@@ -28,6 +28,7 @@ const (
 // ValidateToken is a wrapper to validate token before passing request to provided handler
 func ValidateToken(pathHandler server.HandlerType) server.HandlerType {
 	return func(res http.ResponseWriter, req *http.Request) {
+		log.Printf("ValidateToken Received request: %v", req)
 		providedToken := req.Header.Get(tokenRequestHeader)
 		if providedToken == "" {
 			log.Println("Token required; No token provided.")


### PR DESCRIPTION
**Issue:**
* When requesting a token for imdsv2, the response should contain the token TTL header, `X-aws-ec2-metadata-token-ttl-seconds`

**Description of changes:**
* Added TTL header to response
* Updated unit tests
* Some additional logging

**Testing:**
* **Before Fix:**

```
curl -X PUT -v "localhost:1338/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 1338 (#0)
> PUT /latest/api/token HTTP/1.1
> Host: localhost:1338
> User-Agent: curl/7.54.0
> Accept: */*
> X-aws-ec2-metadata-token-ttl-seconds: 21600
>
< HTTP/1.1 200 OK
< Content-Type: text/plain
< Date: Fri, 26 Jun 2020 15:38:08 GMT
< Content-Length: 44
<
* Connection #0 to host localhost left intact
Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=%
```

* **After Fix:**

```

curl -X PUT -v "localhost:1338/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 1338 (#0)
> PUT /latest/api/token HTTP/1.1
> Host: localhost:1338
> User-Agent: curl/7.54.0
> Accept: */*
> X-aws-ec2-metadata-token-ttl-seconds: 21600
>
< HTTP/1.1 200 OK
< Content-Type: text/plain
< X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600
< Date: Fri, 26 Jun 2020 15:37:22 GMT
< Content-Length: 44
<
* Connection #0 to host localhost left intact
Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=


```

* **Real imdsv2 service:**

```

curl -X PUT -v "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"
*   Trying 169.254.169.254...
* TCP_NODELAY set
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> PUT /latest/api/token HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.61.1
> Accept: */*
> X-aws-ec2-metadata-token-ttl-seconds: 21600
>
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Content-Length: 56
< Content-Type: text/plain
< Date: Thu, 25 Jun 2020 21:33:54 GMT
< X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600
< Connection: close
< Server: EC2ws
<
* Closing connection 0
AQAAALdmt5penYEXtby-c78k359HXacd1mRcTpUwVam00S7mf-qwFw==

```

* NTH imdsv2 test finally passing when using AEMM 🎉

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
