### PR TITLE
adding tolerations and args to helm chart

### DIFF
--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
-version: 0.5.7
+version: 0.5.8
 appVersion: v1.0.1
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png

--- a/helm/amazon-ec2-metadata-mock/Chart.yaml
+++ b/helm/amazon-ec2-metadata-mock/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: amazon-ec2-metadata-mock
 description: A Helm chart for the Amazon EC2 Metadata Mock
-version: 0.5.8
+version: 1.0.1
 appVersion: v1.0.1
 home: https://github.com/aws/amazon-ec2-metadata-mock
 icon: https://raw.githubusercontent.com/aws/amazon-ec2-metadata-mock/master/helm/aws-logo.png

--- a/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
                 - arm64
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+{{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "amazon-ec2-metadata-mock.serviceAccountName" . }}
       hostNetwork: false # turn off host network to prevent undesired exposure of AEMM web server

--- a/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/name: {{ include "amazon-ec2-metadata-mock.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- if .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
 {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -43,6 +43,10 @@ spec:
                 - amd64
                 - arm
                 - arm64
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "amazon-ec2-metadata-mock.serviceAccountName" . }}
       hostNetwork: false # turn off host network to prevent undesired exposure of AEMM web server
       {{- if .Values.configMap }}
@@ -55,6 +59,12 @@ spec:
       - name: {{ include "amazon-ec2-metadata-mock.name" . }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.arguments }}
+        args:
+          {{ range .Values.arguments }}
+            - {{ . }}
+          {{ end }}
+        {{- end }}
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/helm/amazon-ec2-metadata-mock/values.yaml
+++ b/helm/amazon-ec2-metadata-mock/values.yaml
@@ -16,6 +16,12 @@ nodeSelector: {}
 
 podAnnotations: {}
 
+# tolerations specify taints that a pod tolerates so that it can be scheduled to a node with that taint
+tolerations: []
+
+# arguments represent CLI args to use when starting amazon-ec2-metadata-mock
+arguments: []
+
 # updateStrategy represents the update strategy for a DaemonSet
 updateStrategy: "RollingUpdate"
 


### PR DESCRIPTION
*Issue #, if available:*
* When integrating with NTH, it's necessary to specify tolerations and additional args ('spot' vs. 'events')

*Description of changes:*
* Adds tolerations and arguments to values.yaml and consumes them in daemonset template
* Update node selector usage

*Testing:*
* Tested locally with NTH integration tests successfully using:

```

helm upgrade --install $CLUSTER_NAME-aemm /Users/crtbry/workplace/go/src/aemm_brycahta_fork_ws/amazon-ec2-metadata-mock/helm/amazon-ec2-metadata-mock/ \
  --wait \
  --namespace default \
  --set servicePort="$IMDS_PORT" \
  --set 'tolerations[0].effect=NoSchedule' \
  --set 'tolerations[0].operator=Exists' \
  --set arguments={spot}

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
