### PR TITLE
Release prep automation and modify Travis config 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,19 @@ services:
 
 stages:
 - Build and Tests
-- Validate Versions for Release
-- Github Release
-- Docker Release
-- Helm Chart and Docker Image E2E Tests
+- name: Validate Versions for Release
+  if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+- name: Github Release
+  if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
+- name: Docker Release
+  if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKERHUB_TOKEN) IS present
+- name: Helm Chart Lint Test
+  if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+- name: Helm Chart and Docker Image E2E Tests
+  # Skip running this stage when updating release versions as part of release prep
+  # as the new Docker image wouldn't be available yet and previous commits should have already been tested.
+  # Since the release prep commit will be the release commit, always run this stage when a new tag is pushed, as part of a release.
+  if: commit_message !~ /(Skip Helm E2E Tests)/ OR (type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/)
 
 jobs:
   include:
@@ -42,15 +51,12 @@ jobs:
     # stages run on tag creation only
     - stage: Validate Versions for Release
       name: Validate AEMM and Chart versions
-      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/
       script: make validate-release-version
     - stage: Github Release
       name: Github release
-      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
       script: make release-github
     - stage: Docker Release
       name: Docker release
-      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKERHUB_TOKEN) IS present
       script: make release-docker
 
     # Helm E2E tests, to test Helm chart installation on latest Docker image and a local Docker image with unreleased commits, if any.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 LATEST_RELEASE_TAG=$(shell git tag | tail -1)
 PREVIOUS_RELEASE_TAG=$(shell git tag | tail -2 | head -1)
+REPO_FULL_NAME=aws/amazon-ec2-metadata-mock
 IMG ?= amazon/amazon-ec2-metadata-mock
 IMG_TAG ?= ${VERSION}
 IMG_W_TAG = ${IMG}:${IMG_TAG}
@@ -31,6 +32,9 @@ latest-release-tag:
 
 previous-release-tag:
 	@echo ${PREVIOUS_RELEASE_TAG}
+
+repo-full-name:
+	@echo ${REPO_FULL_NAME}
 
 image:
 	@echo ${IMG_W_TAG}
@@ -129,17 +133,17 @@ create-local-tag-for-minor-release:
 create-local-tag-for-patch-release:
 	${MAKEFILE_PATH}/scripts/create-local-tag-for-release -p
 
-update-versions-for-release:
-	${MAKEFILE_PATH}/scripts/update-versions-for-release
+create-release-prep-pr:
+	${MAKEFILE_PATH}/scripts/prepare-for-release
 
-release-prep-major: create-local-tag-for-major-release update-versions-for-release
+release-prep-major: create-local-tag-for-major-release create-release-prep-pr
 
-release-prep-minor: create-local-tag-for-minor-release update-versions-for-release
+release-prep-minor: create-local-tag-for-minor-release create-release-prep-pr
 
-release-prep-patch: create-local-tag-for-patch-release update-versions-for-release
+release-prep-patch: create-local-tag-for-patch-release create-release-prep-pr
 
 release-prep-custom: # Run make NEW_VERSION=1.2.3 release-prep-custom to prep for a custom release version
 ifdef NEW_VERSION
-	$(shell echo "${MAKEFILE_PATH}/scripts/create-local-tag-for-release -v $(NEW_VERSION) && echo && make update-versions-for-release")
+	$(shell echo "${MAKEFILE_PATH}/scripts/create-local-tag-for-release -v $(NEW_VERSION) && echo && make create-release-prep-pr")
 endif
 	

--- a/scripts/create-local-tag-for-release
+++ b/scripts/create-local-tag-for-release
@@ -83,16 +83,32 @@ validate_args() {
     exit 1
 }
 
-# create the new tag
+sync_local_tags_with_remote() {
+    # setup remote upstream tracking to fetch tags
+    git remote add the-real-upstream https://github.com/aws/amazon-ec2-metadata-mock.git &> /dev/null || true
+    git fetch the-real-upstream
+
+    # delete all local tags
+    git tag -l | xargs git tag -d
+
+    # fetch remote tags
+    git fetch the-real-upstream --tags
+
+    # clean up tracking
+    git remote remove the-real-upstream
+}
+
 create_tag() {
     git tag $NEW_TAG
-    echo "🥑 Created new tag $NEW_TAG (Current latest release tag: v$LATEST_TAG)"
+    echo -e "\n✅ Created new tag $NEW_TAG (Current latest release tag: v$LATEST_TAG)\n"
     exit 0
 }
 
 main() {
     process_args $@
     validate_args
+
+    sync_local_tags_with_remote
 
     # if new tag is specified, create it
     if [[ ! -z $NEW_TAG ]]; then

--- a/scripts/create-local-tag-for-release
+++ b/scripts/create-local-tag-for-release
@@ -83,7 +83,7 @@ validate_args() {
     exit 1
 }
 
-sync_local_tags_with_remote() {
+sync_local_tags_from_remote() {
     # setup remote upstream tracking to fetch tags
     git remote add the-real-upstream https://github.com/aws/amazon-ec2-metadata-mock.git &> /dev/null || true
     git fetch the-real-upstream
@@ -108,7 +108,7 @@ main() {
     process_args $@
     validate_args
 
-    sync_local_tags_with_remote
+    sync_local_tags_from_remote
 
     # if new tag is specified, create it
     if [[ ! -z $NEW_TAG ]]; then

--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -27,7 +27,7 @@ MAKEFILE_PATH=$REPO_ROOT_PATH/Makefile
 LATEST_VERSION=$(make -s -f $MAKEFILE_PATH latest-release-tag | cut -b 2- )
 PREVIOUS_VERSION=$(make -s -f $MAKEFILE_PATH previous-release-tag | cut -b 2- )
 
-# Files to update
+# files with versions, to update
 REPO_README=$REPO_ROOT_PATH/README.md
 CHART=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/Chart.yaml
 CHART_VALUES=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/values.yaml

--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Script to:
+## 1) create and checkout a new branch with the latest tag name
+## 2) update AEMM and Helm chart versions
+## 3) commit release prep changes to new branch
+## 4) create a PR from the new branch to upstream/master
+
+## The following files are updated in step (2):
+### - helm charts' Chart.yaml
+### - helm charts' values.yaml
+### - helm charts' README
+### - README.md
+
+# Prerequisites:
+## 1) git and gh cli (make sure to use gh cli before running this script as authentication is required)
+## 2) git tracking is expected to be set as follows: origin=fork (e.g. https://github.com/pdk27/amazon-ec2-metadata-mock-1.git), upstream=https://github.com/aws/amazon-ec2-metadata-mock.git
+## 3) local tag creation is separated from this script and a new tag must be created before this script is run. This is automated when this script is run via make targets.  
+
+# NOTE: only the files updated by this script is included in the commit / PR i.e. release version updates in $FILES
+# This script is NOT intended to be combined with other unmerged local changes
+
+set -o pipefail
+
+REPO_ROOT_PATH="$( cd "$(dirname "$0")"; cd ../; pwd -P )"
+MAKEFILE_PATH=$REPO_ROOT_PATH/Makefile
+LATEST_VERSION=$(make -s -f $MAKEFILE_PATH latest-release-tag | cut -b 2- )
+PREVIOUS_VERSION=$(make -s -f $MAKEFILE_PATH previous-release-tag | cut -b 2- )
+
+# Files to update
+REPO_README=$REPO_ROOT_PATH/README.md
+CHART=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/Chart.yaml
+CHART_VALUES=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/values.yaml
+CHART_README=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/README.md
+FILES=($REPO_README  $CHART  $CHART_README  $CHART_VALUES)
+FILES_CHANGED=()
+
+# release prep
+LATEST_TAG="v$LATEST_VERSION"
+NEW_BRANCH_NAME="pr/$LATEST_TAG-release"
+COMMIT_MESSAGE="🥑🤖 $LATEST_TAG release prep [Skip Helm E2E Tests] 🤖🥑"
+
+# PR
+REPO_FULL_NAME=$(make -s -f $MAKEFILE_PATH repo-full-name)
+PR_BASE=master  # target
+PR_TITLE="🥑🤖 $LATEST_TAG release prep"
+PR_BODY="🥑🤖 Auto-generated PR for $LATEST_TAG release. Updating release versions in repo."
+
+create_release_branch() {
+    git checkout -b $NEW_BRANCH_NAME
+    echo -e "✅ Created new release branch $NEW_BRANCH_NAME\n\n"
+}
+
+update_versions() {
+    # update release version for release prep
+    echo -e "🥑 Attempting to update AEMM release version and Helm chart version in preparation for a new release.\n   Previous version: $PREVIOUS_VERSION ---> Latest version: $LATEST_VERSION"
+
+    for f in ${FILES[@]}; do
+        has_incorrect_version=$(cat $f | grep $PREVIOUS_VERSION)
+        if [[ ! -z  $has_incorrect_version ]]; then
+            sed -i '' "s/$PREVIOUS_VERSION/$LATEST_VERSION/g" $f
+            FILES_CHANGED+=($f)
+        fi
+    done
+
+    if [[ -z $FILES_CHANGED ]]; then
+        echo -e "\nNo files were modified. Either all files already use git the latest release version $LATEST_VERSION or the files don't currently have the previous version $PREVIOUS_VERSION."
+    else
+        echo -e "✅✅ Updated versions from $PREVIOUS_VERSION to $LATEST_VERSION in files: \n$(echo "${FILES_CHANGED[@]}" | tr ' ' '\n')"
+        echo -e "To see changes, run \`git diff HEAD^ HEAD\`"
+    fi
+    echo
+}
+
+commit_changes() {
+    echo -e "\n🥑 Adding and committing release version changes."
+    git add "${FILES_CHANGED[@]}"
+    git commit -m"$COMMIT_MESSAGE"
+    echo -e "✅✅✅ Committed release prep changes to new branch $NEW_BRANCH_NAME with commit message '$COMMIT_MESSAGE'\n\n"
+}
+
+# verify origin tracking before creating and pushing new branches
+verify_origin_tracking() {
+    origin=$(git remote get-url origin 2>&1)
+
+    if [[ $origin == "fatal: No such remote 'origin'" ]] || [[ $origin == "https://github.com/aws/amazon-ec2-metadata-mock.git" ]]; then
+        echo -e "❌ Expected remote 'origin' to be tracking fork but found \"$origin\". Set it up before running this script again."
+        exit 1
+    fi
+}
+
+create_pr() {
+    git push -u origin $NEW_BRANCH_NAME # sets source branch for PR to NEW_BRANCH on the fork or origin
+    gh pr create \
+        --repo "$REPO_FULL_NAME" \
+        --base "$PR_BASE" \
+        --title "$PR_TITLE" \
+        --body "$PR_BODY" \
+        --label "release-prep" --label "🤖 auto-generated🤖"
+
+    if [[ $? == 0 ]]; then
+        echo -e "✅✅✅✅ Created $LATEST_TAG release prep PR\n"
+    else
+        echo -e "❌ PR creation failed.❌"
+        exit 1
+    fi
+}
+
+# rollback partial changes to make this script atomic
+rollback() {
+    # checkout of current branch to master
+    git checkout master
+
+    # delete latest local tag
+    git tag -d $LATEST_TAG
+
+    # delete local and remote release branch
+    git branch -D $NEW_BRANCH_NAME
+    git push origin --delete $NEW_BRANCH_NAME
+}
+
+handle_errors() {
+    # error handling
+    if [ $1 != "0" ]; then
+        FAILED_COMMAND=${@:2}
+        echo -e "\n❌ Error occurred. Rolling back. ❌"
+        rollback
+        exit 1
+    fi
+    exit $1
+}
+
+main() {
+    trap 'handle_errors $? $BASH_COMMAND' EXIT
+
+    verify_origin_tracking
+
+    echo
+    create_release_branch
+    update_versions
+    commit_changes
+    create_pr
+}
+
+main $@


### PR DESCRIPTION
*Description* 
* add script to automate release prep - includes 
  1) create and checkout a new branch with the latest tag name
  2) update AEMM and Helm chart versions
  3) commit release prep changes to new branch  
  4) create a PR from the new branch to upstream/master
* modify travis config to run helm e2e tests conditionally
* improve script to create tag for release by sync-ing local tags before tag creation

*Tests*
Sample auto-generated PR - https://github.com/pdk27/amazon-ec2-metadata-mock-1/pull/8
https://github.com/aws/amazon-ec2-metadata-mock/pull/57 (not perfect, but cut to upstream) 
Output of script - shared internally

