### PR TITLE
adding Dockerfile for Windows support

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,49 @@
+ARG WINDOWS_VERSION=1809
+
+# Build the manager binary
+FROM golang:1.14 as builder
+
+# GOLANG env
+ARG GOPROXY="direct"
+ARG GO111MODULE="on"
+ARG CGO_ENABLED=0
+ARG GOOS=windows
+ARG GOARCH=amd64
+
+# Copy go.mod and download dependencies
+WORKDIR /amazon-ec2-metadata-mock
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Setup to use git-bash on Windows
+SHELL ["cmd", "/S", "/C"]
+# Install Chocolatey
+RUN @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+# Update Path
+RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;"
+
+# New Powershell, so choco is available
+SHELL ["powershell"]
+RUN choco feature disable --name showDownloadProgress
+
+# Install make, git-bash
+RUN choco install make
+RUN choco install git -y
+# Update Path
+SHELL ["cmd", "/S", "/C"]
+RUN setx /M PATH "%PATH%;c:\Program Files\Git\usr\bin"
+
+# Build
+COPY . .
+RUN make build
+# In case the target is build for testing:
+# $ docker build  --target=builder -t test .
+ENTRYPOINT ["/amazon-ec2-metadata-mock/build/ec2-metadata-mock"]
+
+# Copy the controller-manager into a thin image
+FROM mcr.microsoft.com/windows/nanoserver:${WINDOWS_VERSION}
+WORKDIR /
+COPY --from=builder /amazon-ec2-metadata-mock/build/ec2-metadata-mock .
+COPY THIRD_PARTY_LICENSES .
+ENTRYPOINT ["/ec2-metadata-mock"]

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
 BINARY_NAME=ec2-metadata-mock
 METADATA_DEFAULTS_FILE=${MAKEFILE_PATH}/pkg/config/defaults/aemm-metadata-default-values.json
-ENCODED_METADATA_DEFAULTS=$(shell cat ${METADATA_DEFAULTS_FILE} | base64 | tr -d \\n)
+ENCODED_METADATA_DEFAULTS=$(shell cat ${METADATA_DEFAULTS_FILE} | base64 | tr -d '\040\011\012\015')
 DEFAULT_VALUES_VAR=github.com/aws/amazon-ec2-metadata-mock/pkg/config/defaults.encodedDefaultValues
 ROOT_VERSION_VAR=github.com/aws/amazon-ec2-metadata-mock/pkg/cmd/root.version
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* adding Dockerfile.Windows which can be built and run using Docker on Windows
* Updated Makefile to work with `git-bash` on Windows:
  * `tr -d '\040\011\012\015'` removes spaces, tabs, carriage returns, and newlines
    * still works on Mac and Linux


*Testing:*
* Launched EC2 instance with *Microsoft Windows Server 2019 with Containers* ami
* Copied these changes to the instance
* In Powershell or Command Util:
  * `docker build -f Dockerfile.windows` executes successfully
  * `docker run <generated_image>` starts AEMM as expected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
