### PR TITLE
add tar.gz bin files for linux and mac and a zip'd bin for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOPROXY ?= "https://proxy.golang.org,direct"
 SUPPORTED_PLATFORMS ?= "linux/amd64,linux/arm64,linux/arm,darwin/amd64,windows/amd64"
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
-BINARY_NAME=ec2-metadata-mock
+BINARY_NAME ?= ec2-metadata-mock
 METADATA_DEFAULTS_FILE=${MAKEFILE_PATH}/pkg/config/defaults/aemm-metadata-default-values.json
 ENCODED_METADATA_DEFAULTS=$(shell cat ${METADATA_DEFAULTS_FILE} | base64 | tr -d '\040\011\012\015')
 DEFAULT_VALUES_VAR=github.com/aws/amazon-ec2-metadata-mock/pkg/config/defaults.encodedDefaultValues
@@ -35,6 +35,9 @@ previous-release-tag:
 
 repo-full-name:
 	@echo ${REPO_FULL_NAME}
+
+binary-name:
+	@echo ${BINARY_NAME}
 
 image:
 	@echo ${IMG_W_TAG}

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -5,9 +5,11 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 REPO_ROOT_PATH=$SCRIPTPATH/../
 MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
-mkdir -p $SCRIPTPATH/../build/bin
+BIN_DIR=$SCRIPTPATH/../build/bin
+mkdir -p $BIN_DIR
 
 VERSION=$(make -s -f $MAKE_FILE_PATH version)
+BASE_BIN_NAME=$(make -s -f $MAKE_FILE_PATH binary-name)
 PLATFORMS=("linux/amd64")
 PASS_THRU_ARGS=""
 
@@ -17,6 +19,7 @@ USAGE=$(cat << 'EOM'
 
   Example: build-binaries -p "linux/amd64,linux/arm"
           Optional:
+            -b          Base bin name [DEFAULT: output of "make binary-name"]
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
             -d          DIRECT: Set GOPROXY=direct to bypass go proxies
             -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
@@ -24,7 +27,7 @@ EOM
 )
 
 # Process our input arguments
-while getopts "dp:v:" opt; do
+while getopts "dp:v:b:" opt; do
   case ${opt} in
     p ) # Platform Pairs
         IFS=',' read -ra PLATFORMS <<< "$OPTARG"
@@ -34,6 +37,9 @@ while getopts "dp:v:" opt; do
       ;;
     v ) # Image Version
         VERSION="$OPTARG"
+      ;;
+    b ) # Base bin name
+        BASE_BIN_NAME="$OPTARG"
       ;;
     \? )
         echo "$USAGE" 1>&2
@@ -45,17 +51,33 @@ done
 for os_arch in "${PLATFORMS[@]}"; do
     os=$(echo $os_arch | cut -d'/' -f1)
     arch=$(echo $os_arch | cut -d'/' -f2)
-    container_name="extract-aemm-$os-$arch"
-    repo_name="aemm-bin"
+    container_name="build-$BASE_BIN_NAME-$os-$arch"
+    repo_name="bin-build"
 
     if [[ $os == "windows" ]]; then
-        bin_name="ec2-metadata-mock-$os-$arch.exe"
+        bin_name="$BASE_BIN_NAME-$os-$arch.exe"
     else
-        bin_name="ec2-metadata-mock-$os-$arch"
+        bin_name="$BASE_BIN_NAME-$os-$arch"
     fi
 
     docker container rm $container_name || :
     $SCRIPTPATH/build-docker-images -p $os_arch -v $VERSION -r $repo_name $PASS_THRU_ARGS
     docker container create --rm --name $container_name "$repo_name:$VERSION-$os-$arch"
-    docker container cp $container_name:/ec2-metadata-mock $SCRIPTPATH/../build/bin/$bin_name
+    docker container cp $container_name:/ec2-metadata-mock $BIN_DIR/$bin_name
+
+    if [[ $os == "windows" ]]; then
+      ## Create zip archive with binary taking into account windows .exe
+      cp ${BIN_DIR}/${bin_name} ${BIN_DIR}/${BASE_BIN_NAME}.exe
+      ## Can't reuse bin_name below because it includes .exe  
+      curr_dir=$(pwd)
+      cd "${BIN_DIR}"
+      zip -9 -q ${BASE_BIN_NAME}-$os-$arch.zip ${BASE_BIN_NAME}.exe
+      cd "${curr_dir}"
+      rm -f ${BIN_DIR}/${BASE_BIN_NAME}.exe
+    else
+      ## Create tar.gz archive with binary
+      cp ${BIN_DIR}/${bin_name} ${BIN_DIR}/${BASE_BIN_NAME}
+      tar -zcvf ${BIN_DIR}/${bin_name}.tar.gz -C ${BIN_DIR} ${BASE_BIN_NAME}
+      rm -f ${BIN_DIR}/${BASE_BIN_NAME}
+    fi
 done


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Generate tar.gz bin files for more efficient downloads and for use as static bottles for homebrew.
 - Generate .zip bin file for windows


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
