### PR TITLE
extend support to k8s versions 1.12 and 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,3 +91,9 @@ jobs:
     - name: Helm chart / Docker Image Tests for K8s v1.14
       script: test/helm/chart-test.sh -i -k $K8S_VERSION
       env: K8S_VERSION=1.14
+    - name: Helm chart / Docker Image Tests for K8s v1.13
+      script: test/helm/chart-test.sh -i -k $K8S_VERSION
+      env: K8S_VERSION=1.13
+    - name: Helm chart / Docker Image Tests for K8s v1.12
+      script: test/helm/chart-test.sh -i -k $K8S_VERSION
+      env: K8S_VERSION=1.12

--- a/helm/amazon-ec2-metadata-mock/templates/clusterrole.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/clusterrole.yaml
@@ -4,4 +4,4 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "amazon-ec2-metadata-mock.fullname" . }}
-rules: # empty rules array to disallow all permissions for AEMM 
+rules: [] # empty rules array to disallow all permissions for AEMM

--- a/test/helm/chart-test.sh
+++ b/test/helm/chart-test.sh
@@ -23,6 +23,8 @@ readonly K8s_1_17="v1.17.5"
 readonly K8s_1_16="v1.16.9"
 readonly K8s_1_15="v1.15.11"
 readonly K8s_1_14="v1.14.10"
+readonly K8s_1_13="v1.13.12"
+readonly K8s_1_12="v1.12.10"
 KIND_IMAGE="$K8s_1_18"
 readonly KIND_VERSION="v0.8.1"
 readonly CLUSTER_NAME="kind-ct"
@@ -264,7 +266,12 @@ process_args() {
               ;;
             k )
               OPTARG="K8s_$(echo $OPTARG | sed 's/\./\_/g')"
-              KIND_IMAGE="${!OPTARG}"
+              if [ ! -z ${!OPTARG+x} ]; then
+                KIND_IMAGE=${!OPTARG}
+              else
+                echo "K8s version not supported" 1>&2
+                exit 2
+              fi
               ;;
             c )
               CT_TAG=$OPTARG


### PR DESCRIPTION
**Issue #, if available:**
* No issue #, but NTH PR is failing because current AEMM helm chart's `rules` value for k8s versions 1.12 + 1.13
  * https://travis-ci.org/github/aws/aws-node-termination-handler/jobs/709333749

**Description of changes:**
* rules as an empty array to correct parsing error in k8s 1.12 an 1.13
* corrected check on `${!OPTARG}`
  * **note: needs to be done in NTH as well**
* Now that NTH uses AEMM for its integ tests, AEMM needs to support the same k8s versions as NTH; therefore adding 1.12 and 1.13 support

**Local Testing:**
* All pass successfully:
  * test/helm/chart-test.sh -i -k 1.12
  * test/helm/chart-test.sh -i -k 1.13
  * test/helm/chart-test.sh -i -k 1.18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
