### PR TITLE
fix push-docker-images logic to populate manifest correctly

### DIFF
--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -52,6 +52,16 @@ if [[ ${#PLATFORMS[@]} -gt 1 && $MANIFEST != "true" ]]; then
     exit 1
 fi
 
+# Existing manifests cannot be updated only overwritten; therefore,
+# if manifest exists already, fetch existing platforms so "updated" manifest includes images
+# that were there previously
+if [[ $MANIFEST == "true" ]]; then
+  manifest_exists=$(docker manifest inspect $IMAGE_REPO:$VERSION > /dev/null ; echo $?)
+  if [[ manifest_exists -eq 0 ]]; then
+    PLATFORMS+=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)"'))
+  fi
+fi
+
 for os_arch in "${PLATFORMS[@]}"; do
     os=$(echo $os_arch | cut -d'/' -f1)
     arch=$(echo $os_arch | cut -d'/' -f2)
@@ -76,15 +86,7 @@ if [[ $MANIFEST == "true" ]]; then
     fi
     cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
     echo "Enabled experimental CLI features to create the docker manifest"
-
-    manifest_create_args=($IMAGE_REPO:$VERSION $MANIFEST_IMAGES)
-    manifest_exists=$(docker manifest inspect $IMAGE_REPO:$VERSION > /dev/null ; echo $?)
-    # manifest already exists; therefore, amend is required
-    if [[ manifest_exists -eq 0 ]]; then
-      manifest_create_args+=(--amend)
-    fi
-
-    docker manifest create "${manifest_create_args[@]}"
+    docker manifest create $IMAGE_REPO:$VERSION $MANIFEST_IMAGES
 
     for os_arch in "${PLATFORMS[@]}"; do
         os=$(echo $os_arch | cut -d'/' -f1)
@@ -95,5 +97,5 @@ if [[ $MANIFEST == "true" ]]; then
         docker manifest annotate $IMAGE_REPO:$VERSION $img_tag --arch $arch --os $os
     done
 
-    docker manifest push $IMAGE_REPO:$VERSION
+    docker manifest push --purge $IMAGE_REPO:$VERSION
 fi


### PR DESCRIPTION
*Issue #, if available:*
- No #, but the issue is during AEMM release, the `Docker Release Windows` stage will overwrite existing manifest leaving it populated with **only windows/amd64** and erasing linux distros that were there previously.
- I thought this worked before, but the manifest was cached on my machine from previous upload making it appear as if it were working

*Description of changes:*
* Check for existence of manifest and update PLATFORMS accordingly
* added `--purge` to push to clear local cache

*Testing:*
* very locally tested on my test Dockerhub repo with no local cache this time

*Notes:*
* `--amend` is useless

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
