### PR TITLE
prevent push-docker-images from overwriting existing manifest

### DIFF
--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -56,6 +56,12 @@ fi
 # if manifest exists already, fetch existing platforms so "updated" manifest includes images
 # that were there previously
 if [[ $MANIFEST == "true" ]]; then
+    if [[ ! -f $DOCKER_CLI_CONFIG ]]; then
+      echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
+      echo "Created docker config file"
+    fi
+    cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
+    echo "Enabled experimental CLI features to execute docker manifest commands"
   manifest_exists=$(docker manifest inspect $IMAGE_REPO:$VERSION > /dev/null ; echo $?)
   if [[ manifest_exists -eq 0 ]]; then
     PLATFORMS+=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)"'))
@@ -80,12 +86,8 @@ for os_arch in "${PLATFORMS[@]}"; do
 done
 
 if [[ $MANIFEST == "true" ]]; then
-    if [[ ! -f $DOCKER_CLI_CONFIG ]]; then
-      echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
-      echo "Created docker config file"
-    fi
-    cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
-    echo "Enabled experimental CLI features to create the docker manifest"
+
+    echo "creating manifest for the following images: $MANIFEST_IMAGES"
     docker manifest create $IMAGE_REPO:$VERSION $MANIFEST_IMAGES
 
     for os_arch in "${PLATFORMS[@]}"; do


### PR DESCRIPTION
*Issue #, if available:* 
* During v1.3.0 release the docker manifest was overwritten with Windows image **only** which caused subsequent helm testing to fail due to Linux images not being available.

*Description of changes:*
* enable experimental Docker CLI features **before** running `manifest inspect` to check if manifest exists already. Otherwise, manifest will be overwritten and the following error: `docker manifest inspect is only supported on a Docker cli with experimental cli features enabled`
  * related log from v1.3.0 release: https://travis-ci.org/github/aws/amazon-ec2-metadata-mock/jobs/716661941


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
