### PR TITLE
fixing push-docker-images to update manifest correctly

### DIFF
--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -8,7 +8,7 @@ MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
 
 VERSION=$(make -s -f $MAKE_FILE_PATH version)
 PLATFORMS=("linux/amd64")
-MANIFEST_IMAGES=""
+MANIFEST_IMAGES=()
 MANIFEST=""
 DOCKER_CLI_CONFIG="$HOME/.docker/config.json"
 
@@ -56,15 +56,22 @@ fi
 # if manifest exists already, fetch existing platforms so "updated" manifest includes images
 # that were there previously
 if [[ $MANIFEST == "true" ]]; then
-    if [[ ! -f $DOCKER_CLI_CONFIG ]]; then
-      echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
-      echo "Created docker config file"
-    fi
-    cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
-    echo "Enabled experimental CLI features to execute docker manifest commands"
+  if [[ ! -f $DOCKER_CLI_CONFIG ]]; then
+    echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
+    echo "Created docker config file"
+  fi
+  cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
+  echo "Enabled experimental CLI features to execute docker manifest commands"
   manifest_exists=$(docker manifest inspect $IMAGE_REPO:$VERSION > /dev/null ; echo $?)
   if [[ manifest_exists -eq 0 ]]; then
-    PLATFORMS+=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)"'))
+    echo "manifest already exists"
+    EXISTING_IMAGES=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"'))
+    # treat separate from PLATFORMS because existing images don't need to be tagged and pushed
+    for os_arch in "${EXISTING_IMAGES[@]}"; do
+      img_tag="$IMAGE_REPO:$VERSION-$os_arch"
+      MANIFEST_IMAGES+=($img_tag)
+    done
+    echo "images already in manifest: $MANIFEST_IMAGES"
   fi
 fi
 
@@ -80,24 +87,33 @@ for os_arch in "${PLATFORMS[@]}"; do
         img_tag="$IMAGE_REPO:$VERSION"
         docker tag $img_tag_w_platform $img_tag
     fi
-
     docker push $img_tag
-    MANIFEST_IMAGES="$MANIFEST_IMAGES $img_tag"
+    MANIFEST_IMAGES+=($img_tag)
 done
 
 if [[ $MANIFEST == "true" ]]; then
+    current_os=$(uname)
+    # Windows will append '\r' to the end of $img which
+    # results in docker failing to create the manifest due to invalid reference format.
+    # However, MacOS does not recognize '\r' as carriage return
+    # and attempts to remove literal 'r' chars; therefore, made this so portable
+    for img in "${MANIFEST_IMAGES[@]}"; do
+      if [[ $current_os == "Darwin" ]]; then
+        updated_img=$img
+      else
+        updated_img=$(echo $img | sed -e 's/\r$//')
+      fi
+      echo "creating manifest for $updated_img"
+      docker manifest create $IMAGE_REPO:$VERSION $updated_img --amend
 
-    echo "creating manifest for the following images: $MANIFEST_IMAGES"
-    docker manifest create $IMAGE_REPO:$VERSION $MANIFEST_IMAGES
+      os_arch=$(echo ${updated_img//$IMAGE_REPO:$VERSION-/})
+      os=$(echo $os_arch | cut -d'-' -f1)
+      arch=$(echo $os_arch | cut -d'-' -f2)
 
-    for os_arch in "${PLATFORMS[@]}"; do
-        os=$(echo $os_arch | cut -d'/' -f1)
-        arch=$(echo $os_arch | cut -d'/' -f2)
-
-        img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
-
-        docker manifest annotate $IMAGE_REPO:$VERSION $img_tag --arch $arch --os $os
+      echo "annotating manifest"
+      docker manifest annotate $IMAGE_REPO:$VERSION $updated_img --arch $arch --os $os
     done
 
+    echo "pushing manifest"
     docker manifest push --purge $IMAGE_REPO:$VERSION
 fi


### PR DESCRIPTION
*Issue #, if available:* 
* this fixes the dockerhub manifest so that subsequent releases **update** and **annotate** manifest correctly without overwriting it

*Description of changes:*
* `MANIFEST_IMAGES` is an array; existing images in the manifest will be added directly here
* using `manifest create --amend` because for-loop is the only way I can get Windows to register multiple manifest images at once
* fixed spacing
* added more `echo` for easier debugging in Travis

*Testing:*
* https://travis-ci.org/github/brycahta/amazon-ec2-metadata-mock/builds/717368709
  * ignore the Helm ish
* Test Dockerhub aka Dockershub with all images in manifest: https://hub.docker.com/repository/docker/brycahta/dockershub/tags?page=1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
