### PR TITLE
Add MockTriggerTime setting to return events and spot interruptions at a specific time

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,18 +128,20 @@ Examples:
   ec2-metadata-mock spot --action terminate	mocks spot ITN only
 
 Available Commands:
-  events          Mock EC2 maintenance events
-  help            Help about any command
-  spot            Mock EC2 Spot interruption notice
+  events      Mock EC2 maintenance events
+  help        Help about any command
+  spot        Mock EC2 Spot interruption notice
 
 Flags:
-  -c, --config-file string    config file for cli input parameters in json format (default: $HOME/aemm-config.json)
-  -h, --help                  help for amazon-ec2-metadata-mock
-  -n, --hostname string       the HTTP hostname for the mock url (default: localhost)
-  -I, --imdsv2                whether to enable IMDSv2 only requiring a session token when submitting requests (default: false)
-  -d, --mock-delay-sec int    mock delay in seconds, relative to the application start time (default: 0 seconds)
-  -p, --port string           the HTTP port where the mock runs (default: 1338)
-  -s, --save-config-to-file   whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+  -c, --config-file string         config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -h, --help                       help for ec2-metadata-mock
+  -n, --hostname string            the HTTP hostname for the mock url (default: 0.0.0.0)
+  -I, --imdsv2                     whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int         mock delay in seconds, relative to the application start time (default: 0 seconds)
+      --mock-trigger-time string   mock trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
+  -p, --port string                the HTTP port where the mock runs (default: 1338)
+  -s, --save-config-to-file        whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+      --version                    version for ec2-metadata-mock
 
 Use "ec2-metadata-mock [command] --help" for more information about a command.
 ```
@@ -245,25 +247,26 @@ Usage:
   ec2-metadata-mock spot [--action ACTION] [flags]
 
 Aliases:
-  spot, spotitn
+  spot, spot
 
 Examples:
   ec2-metadata-mock spot -h 	spot help
   ec2-metadata-mock spot -d 5 --action terminate		mocks spot interruption only
 
 Flags:
-  -h, --help                      help for spot
-  -a, --action string             action in the spot interruption notice (default: terminate)
-                                  action can be one of the following: terminate,hibernate,stop
-  -t, --time string               time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
+  -a, --action string   action in the spot interruption notice (default: terminate)
+                        action can be one of the following: terminate,hibernate,stop
+  -h, --help            help for spot
+  -t, --time string     termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
-  -c, --config-file string    config file for cli input parameters in json format (default: $HOME/aemm-config.json)
-  -n, --hostname string       the HTTP hostname for the mock url (default: localhost)
-  -I, --imdsv2                whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
-  -d, --mock-delay-sec int    mock delay in seconds, relative to the application start time (default: 0 seconds)
-  -p, --port string           the HTTP port where the mock runs (default: 1338)
-  -s, --save-config-to-file   whether to save processed config from all input sources in .amazon-ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+  -c, --config-file string         config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -n, --hostname string            the HTTP hostname for the mock url (default: 0.0.0.0)
+  -I, --imdsv2                     whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int         mock delay in seconds, relative to the application start time (default: 0 seconds)
+      --mock-trigger-time string   mock trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
+  -p, --port string                the HTTP port where the mock runs (default: 1338)
+  -s, --save-config-to-file        whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
 ```
 
 1.) **Starting AEMM with `spot`**:  `spot` routes available immediately:
@@ -325,6 +328,8 @@ $ curl localhost:1338/latest/meta-data/spot/instance-action
 }
 
 ```
+
+Alternatively a trigger time can be configured using `--mock-trigger-time` which can be useful to synchronize spot interruption simulation over multiple instances. 
 
 ## Events
 Similar to spot, the `events` command, view the local flags using `events --help`:

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -199,6 +199,7 @@ Parameter | Description | Default in Helm | Default AEMM configuration
 --- | --- | --- | ---
 `aemm.server.hostname` | hostname to run AEMM on | `""`, in order to listen on all available interfaces e.g. ClusterIP | `0.0.0.0`
 `aemm.mockDelaySec` | mock delay in seconds, relative to the start time of AEMM | `0` | `0`
+`aemm.mockTriggerTime` | mock trigger time in RFC3339 format | `""` | `""`
 `aemm.imdsv2` | if true, IMDSv2 only works | `false` | `false`, meaning both IMDSv1/v2 work 
 `aemm.spot.action` | action in the spot interruption notice | `""` | `terminate`
 `aemm.spot.time` | time in the spot interruption notice | `""` | HTTP request time + 2 minutes

--- a/helm/amazon-ec2-metadata-mock/templates/daemonset.linux.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/daemonset.linux.yaml
@@ -102,6 +102,10 @@ spec:
         - name: AEMM_MOCK_DELAY_SEC
           value: {{ .Values.aemm.mockDelaySec | quote }}
         {{- end }}
+        {{- if .Values.aemm.mockTriggerTime }}
+        - name: AEMM_MOCK_TRIGGER_TIME
+          value: {{ .Values.aemm.mockTriggerTime | quote }}
+        {{- end }}
         {{- if .Values.aemm.imdsv2 }}
         - name: AEMM_IMDSV2
           value: {{ .Values.aemm.imdsv2| quote }}

--- a/helm/amazon-ec2-metadata-mock/templates/daemonset.windows.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/daemonset.windows.yaml
@@ -87,6 +87,10 @@ spec:
         - name: AEMM_MOCK_DELAY_SEC
           value: {{ .Values.aemm.mockDelaySec | quote }}
         {{- end }}
+        {{- if .Values.aemm.mockTriggerTime }}
+        - name: AEMM_MOCK_TRIGGER_TIME
+          value: {{ .Values.aemm.mockTriggerTime | quote }}
+        {{- end }}
         {{- if .Values.aemm.imdsv2 }}
         - name: AEMM_IMDSV2
           value: {{ .Values.aemm.imdsv2| quote }}

--- a/helm/amazon-ec2-metadata-mock/values.yaml
+++ b/helm/amazon-ec2-metadata-mock/values.yaml
@@ -82,6 +82,7 @@ aemm:
   server:
     hostname: ""
   mockDelaySec: 0
+  mockTriggerTime: ""
   imdsv2: false
   spot:
     action: ""

--- a/pkg/cmd/root/globalflags/globalflags.go
+++ b/pkg/cmd/root/globalflags/globalflags.go
@@ -24,6 +24,9 @@ const (
 	// MockDelayInSecFlag - mock delay in seconds, relative to the application start time
 	MockDelayInSecFlag = "mock-delay-sec"
 
+	// MockTriggerTimeFlag - mock trigger time in RFC3339
+	MockTriggerTimeFlag = "mock-trigger-time"
+
 	// HostNameFlag - the HTTP hostname for the mock url
 	HostNameFlag = "hostname"
 
@@ -36,5 +39,5 @@ const (
 
 // GetTopLevelFlags returns the top level global flags
 func GetTopLevelFlags() []string {
-	return []string{ConfigFileFlag, SaveConfigToFileFlag, MockDelayInSecFlag, Imdsv2Flag}
+	return []string{ConfigFileFlag, SaveConfigToFileFlag, MockDelayInSecFlag, MockTriggerTimeFlag, Imdsv2Flag}
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -42,6 +42,7 @@ var (
 	defaultCfg  = map[string]interface{}{
 		gf.ConfigFileFlag:       cfg.GetDefaultCfgFileName(),
 		gf.MockDelayInSecFlag:   0,
+		gf.MockTriggerTimeFlag:  "",
 		gf.SaveConfigToFileFlag: false,
 		gf.Imdsv2Flag:           false,
 	}
@@ -77,6 +78,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringP(gf.ConfigFileFlag, "c", "", "config file for cli input parameters in json format (default: "+cfg.GetDefaultCfgFileName()+")")
 	cmd.PersistentFlags().BoolP(gf.SaveConfigToFileFlag, "s", false, "whether to save processed config from all input sources in "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
 	cmd.PersistentFlags().Int64P(gf.MockDelayInSecFlag, "d", 0, "mock delay in seconds, relative to the application start time (default: 0 seconds)")
+	cmd.PersistentFlags().String(gf.MockTriggerTimeFlag, "", "mock trigger time in RFC3339 (default: none)")
 	cmd.PersistentFlags().BoolP(gf.Imdsv2Flag, "I", false, "whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)")
 
 	// add subcommands
@@ -144,6 +146,12 @@ func validateConfig() []string {
 	// validate subcommands' config
 	errStrings = append(errStrings, spot.ValidateLocalConfig()...)
 	errStrings = append(errStrings, events.ValidateLocalConfig()...)
+
+	if c.MockTriggerTime != "" {
+		if err := cmdutil.ValidateRFC3339TimeFormat(gf.MockTriggerTimeFlag, c.MockTriggerTime); err != nil {
+			errStrings = append(errStrings, err.Error())
+		}
+	}
 
 	return errStrings
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -78,7 +78,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringP(gf.ConfigFileFlag, "c", "", "config file for cli input parameters in json format (default: "+cfg.GetDefaultCfgFileName()+")")
 	cmd.PersistentFlags().BoolP(gf.SaveConfigToFileFlag, "s", false, "whether to save processed config from all input sources in "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
 	cmd.PersistentFlags().Int64P(gf.MockDelayInSecFlag, "d", 0, "mock delay in seconds, relative to the application start time (default: 0 seconds)")
-	cmd.PersistentFlags().String(gf.MockTriggerTimeFlag, "", "mock trigger time in RFC3339 (default: none)")
+	cmd.PersistentFlags().String(gf.MockTriggerTimeFlag, "", "mock trigger time in RFC3339 format. This takes priority over "+gf.MockDelayInSecFlag+" (default: none)")
 	cmd.PersistentFlags().BoolP(gf.Imdsv2Flag, "I", false, "whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)")
 
 	// add subcommands

--- a/pkg/cmd/root/root_test.go
+++ b/pkg/cmd/root/root_test.go
@@ -31,7 +31,7 @@ func TestNewCmdName(t *testing.T) {
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for root command to be %s, but was %s", expected, actual))
 }
 func TestNewCmdFlags(t *testing.T) {
-	expectedFlags := []string{"config-file", "save-config-to-file", "mock-delay-sec", "hostname", "port", "imdsv2"}
+	expectedFlags := []string{"config-file", "save-config-to-file", "mock-delay-sec", "mock-trigger-time", "hostname", "port", "imdsv2"}
 
 	cmd := NewCmd()
 	actualFlagSet := cmd.PersistentFlags()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -29,6 +29,7 @@ type Config struct {
 	// config keys that are also cli flags
 	CfgFile          string `mapstructure:"config-file"`
 	MockDelayInSec   int64  `mapstructure:"mock-delay-sec"`
+	MockTriggerTime  string `mapstructure:"mock-trigger-time"`
 	SaveConfigToFile bool   `mapstructure:"save-config-to-file"`
 	Server           Server `mapstructure:"server"`
 	Imdsv2Required   bool   `mapstructure:"imdsv2"`

--- a/test/e2e/cmd/root-test
+++ b/test/e2e/cmd/root-test
@@ -54,6 +54,38 @@ function test_root_delay() {
   clean_up $pid
 }
 
+function test_root_mock_trigger_time() {
+  pid=$1
+  delay_in_sec=$2
+  mock_trigger_time=$3
+  tput setaf $CYAN
+
+  # Give server time to startup
+  sleep 1
+  expected_delayed_response=$(cat $SCRIPTPATH/golden/404_response.golden)
+
+  # Subcommand paths are delayed
+  TOKEN=$(get_v2Token $MAX_TOKEN_TTL $AEMM_PORT)
+  actual_response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $ROOT_TEST_PATH/latest/meta-data/spot/instance-action || :)
+  assert_value "$actual_response" "$expected_delayed_response" "test_root_mock_trigger_time::pre-trigger_response"
+
+  # Send request after mock_trigger_time
+  echo "⏲ Waiting on mock_trigger_time ⏲"
+  sleep $delay_in_sec
+  actual_response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $ROOT_TEST_PATH/latest/meta-data/spot/instance-action || :)
+  assert_not_equal "$actual_response" "$expected_delayed_response" "test_root_mock_trigger_time::post-trigger_response"
+
+  # Confirm response isn't empty
+  if [[ ! -z $actual_response ]]; then
+    echo "✅ Verified post-mock_trigger_time response"
+  else
+    echo "❌ Failed delay: there should be a response after mock_trigger_time"
+    EXIT_CODE_TO_RETURN=1
+  fi
+
+  clean_up $pid
+}
+
 tput setaf $CYAN
 echo "======================================================================================================"
 echo "🥑 Starting root integration tests $METADATA_VERSION"
@@ -86,5 +118,15 @@ test_root $ROOT_PID "$ROOT_TEST_PATH/latest/meta-data" "$SCRIPTPATH/golden/root_
 $start_cmd &
 ROOT_PID=$!
 test_root_delay $ROOT_PID $DELAY_IN_SEC
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  mock_trigger_time=$(date --date "${DELAY_IN_SEC} seconds" +%Y-%m-%dT%T%:z)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  mock_trigger_time=$(date -v+${DELAY_IN_SEC}S +%Y-%m-%dT%T%z | sed 's@^.\{22\}@&:@')
+fi
+start_cmd=$(create_cmd $METADATA_VERSION --port $AEMM_PORT --mock-trigger-time "$mock_trigger_time")
+$start_cmd &
+ROOT_PID=$!
+test_root_mock_trigger_time $ROOT_PID $DELAY_IN_SEC "$mock_trigger_time"
 
 exit $EXIT_CODE_TO_RETURN

--- a/test/e2e/testdata/aemm-config-integ.json
+++ b/test/e2e/testdata/aemm-config-integ.json
@@ -10,8 +10,7 @@
   },
   "spot": {
     "action": "terminate",
-    "time": "2020-01-07T01:03:47Z",
-    "trigger-time": "2020-01-07T01:01:47Z"
+    "time": "2020-01-07T01:03:47Z"
   },
   "dynamic": {
     "values": {

--- a/test/e2e/testdata/aemm-config-integ.json
+++ b/test/e2e/testdata/aemm-config-integ.json
@@ -10,7 +10,8 @@
   },
   "spot": {
     "action": "terminate",
-    "time": "2020-01-07T01:03:47Z"
+    "time": "2020-01-07T01:03:47Z",
+    "trigger-time": "2020-01-07T01:01:47Z"
   },
   "dynamic": {
     "values": {


### PR DESCRIPTION
*Description of changes:*

This adds a new config setting to specify an RFC3339 timestamp as an alternative to a mock delay. When the timestamp is reached the server will return the mock events or spot interruption.
We use this feature to simulate the interruption of many spot instances at once which requires a better timing than the startup delay

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
