### PR TITLE
Add Amazon EC2 Spot Instances Integration Roadmap to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,8 @@ For build instructions, please consult [BUILD.md](https://github.com/aws/amazon-
 # Communication
 If you've run into a bug or have a new feature request, please open an [issue](https://github.com/aws/amazon-ec2-metadata-mock/issues/new).
 
+Check out the open source [Amazon EC2 Spot Instances Integrations Roadmap](https://github.com/aws/ec2-spot-instances-integrations-roadmap) to see what we're working on and give us feedback!
+
 # Contributing
 Contributions are welcome! Please read our [guidelines](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/aws/amazon-ec2-metadata-mock/blob/master/CODE_OF_CONDUCT.md)
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add Amazon EC2 Spot Instances Integration Roadmap to readme


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
