### PR TITLE
reconcile shellcheck warnings

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -21,18 +21,16 @@ SHELL ["cmd", "/S", "/C"]
 # Install Chocolatey
 RUN @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
 # Update Path
-RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;"
+RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\usr\bin;C:\Python3;C:\Windows\system32"
 
 # New Powershell, so choco is available
 SHELL ["powershell"]
 RUN choco feature disable --name showDownloadProgress
 
-# Install make, git-bash
+# Install make, git-bash, python
 RUN choco install make
 RUN choco install git -y
-# Update Path
-SHELL ["cmd", "/S", "/C"]
-RUN setx /M PATH "%PATH%;c:\Program Files\Git\usr\bin"
+RUN choco install python3 -y --params "/InstallDir:C:\Python3"
 
 # Build
 COPY . .

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -21,7 +21,7 @@ SHELL ["cmd", "/S", "/C"]
 # Install Chocolatey
 RUN @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
 # Update Path
-RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\usr\bin;C:\Python3;C:\Windows\system32"
+RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows;C:\Windows\system32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;"
 
 # New Powershell, so choco is available
 SHELL ["powershell"]
@@ -31,6 +31,9 @@ RUN choco feature disable --name showDownloadProgress
 RUN choco install make
 RUN choco install git -y
 RUN choco install python3 -y --params "/InstallDir:C:\Python3"
+# Update Path; need to append C:\Windows\system32 to the end to give GitBash find priority
+SHELL ["cmd", "/S", "/C"]
+RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\usr\bin;C:\Python3;C:\Windows\system32"
 
 # Build
 COPY . .

--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -32,7 +32,7 @@ REPO_README=$REPO_ROOT_PATH/README.md
 CHART=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/Chart.yaml
 CHART_VALUES=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/values.yaml
 CHART_README=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/README.md
-FILES=($REPO_README  $CHART  $CHART_README  $CHART_VALUES)
+FILES=("$REPO_README"  "$CHART"  "$CHART_README"  "$CHART_VALUES")
 FILES_CHANGED=()
 
 # release prep
@@ -135,11 +135,11 @@ update_versions() {
         has_incorrect_version=$(cat $f | grep $PREVIOUS_VERSION)
         if [[ ! -z  $has_incorrect_version ]]; then
             sed -i '' "s/$PREVIOUS_VERSION/$LATEST_VERSION/g" $f
-            FILES_CHANGED+=($f)
+            FILES_CHANGED+=("$f")
         fi
     done
 
-    if [[ -z $FILES_CHANGED ]]; then
+    if [[ ${#FILES_CHANGED[@]} -eq 0 ]]; then
         echo -e "\nNo files were modified. Either all files already use git the latest release version $LATEST_VERSION or the files don't currently have the previous version $PREVIOUS_VERSION."
     else
         echo -e "✅✅ ${BOLD}Updated versions from $PREVIOUS_VERSION to $LATEST_VERSION in files: \n$(echo "${FILES_CHANGED[@]}" | tr ' ' '\n')"
@@ -228,7 +228,7 @@ rollback() {
 handle_errors() {
     # error handling
     if [ $1 != "0" ]; then
-        FAILED_COMMAND=${@:2}
+        FAILED_COMMAND=${*:2}
         echo -e "\n❌ ${RED}Error occurred while running command '$FAILED_COMMAND'.${RESET_FMT}❌"
         rollback
         exit 1

--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -60,18 +60,21 @@ if [[ $MANIFEST == "true" ]]; then
     echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
     echo "Created docker config file"
   fi
-  cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
+  cat <<< "$(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG)" > $DOCKER_CLI_CONFIG
   echo "Enabled experimental CLI features to execute docker manifest commands"
   manifest_exists=$(docker manifest inspect $IMAGE_REPO:$VERSION > /dev/null ; echo $?)
   if [[ manifest_exists -eq 0 ]]; then
     echo "manifest already exists"
-    EXISTING_IMAGES=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"'))
+    EXISTING_IMAGES=()
+    while IFS='' read -r line; do
+      EXISTING_IMAGES+=("$line");
+    done < <(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"')
     # treat separate from PLATFORMS because existing images don't need to be tagged and pushed
     for os_arch in "${EXISTING_IMAGES[@]}"; do
       img_tag="$IMAGE_REPO:$VERSION-$os_arch"
-      MANIFEST_IMAGES+=($img_tag)
+      MANIFEST_IMAGES+=("$img_tag")
     done
-    echo "images already in manifest: $MANIFEST_IMAGES"
+    echo "images already in manifest: ${MANIFEST_IMAGES[*]}"
   fi
 fi
 
@@ -88,7 +91,7 @@ for os_arch in "${PLATFORMS[@]}"; do
         docker tag $img_tag_w_platform $img_tag
     fi
     docker push $img_tag
-    MANIFEST_IMAGES+=($img_tag)
+    MANIFEST_IMAGES+=("$img_tag")
 done
 
 if [[ $MANIFEST == "true" ]]; then

--- a/scripts/update-versions-for-release
+++ b/scripts/update-versions-for-release
@@ -9,7 +9,7 @@
 
 # This script is run AFTER creating a new local tag (see `make release-prep`).
 
-set -uo pipefail
+set -euo pipefail
 
 REPO_ROOT_PATH="$( cd "$(dirname "$0")"; cd ../; pwd -P )"
 MAKEFILE_PATH=$REPO_ROOT_PATH/Makefile
@@ -22,7 +22,7 @@ CHART=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/Chart.yaml
 CHART_VALUES=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/values.yaml
 CHART_README=$REPO_ROOT_PATH/helm/amazon-ec2-metadata-mock/README.md
 
-FILES=($REPO_README  $CHART  $CHART_README  $CHART_VALUES)
+FILES=("$REPO_README"  "$CHART"  "$CHART_README"  "$CHART_VALUES")
 FILES_CHANGED=()
 
 echo -e "🥑 Attempting to update AEMM release version and Helm chart version in preparation for a new release.\n   Previous version: $PREVIOUS_VERSION ---> Latest version: $LATEST_VERSION"
@@ -31,11 +31,11 @@ for f in "${FILES[@]}"; do
     has_incorrect_version=$(cat $f | grep $PREVIOUS_VERSION)
     if [[ ! -z  $has_incorrect_version ]]; then
         sed -i '' "s/$PREVIOUS_VERSION/$LATEST_VERSION/g" $f
-        FILES_CHANGED+=($f)
+        FILES_CHANGED+=("$f")
     fi
 done
 
-if [[ ! -z $FILES_CHANGED ]]; then
+if [[ ${#FILES_CHANGED[@]} -gt 0 ]]; then
     echo -e "\n✅ Updated versions from $PREVIOUS_VERSION to $LATEST_VERSION in files: \n$(echo "${FILES_CHANGED[@]}" | tr ' ' '\n')"
     echo -e "\n🥑 To see changes, run \`git diff ${FILES_CHANGED[*]}\`"
 else

--- a/scripts/upload-resources-to-github
+++ b/scripts/upload-resources-to-github
@@ -31,7 +31,7 @@ handle_errors_and_cleanup() {
 
     if [[ ${#ASSET_IDS_UPLOADED[@]} -ne 0 ]]; then
         echo -e "\nCleaning up assets uploaded in the current execution of the script"
-        for asset_id in $ASSET_IDS_UPLOADED; do
+        for asset_id in "${ASSET_IDS_UPLOADED[@]}"; do
             echo "Deleting asset $asset_id"
             curl -X DELETE \
             -H "Authorization: token $GITHUB_TOKEN" \
@@ -42,20 +42,20 @@ handle_errors_and_cleanup() {
 }
 
 gather_assets_to_upload() {
-    local resources=($INDV_K8S_RESOURCES $AGG_K8S_RESOURCES)
+    local resources=("$INDV_K8S_RESOURCES" "$AGG_K8S_RESOURCES")
     for archive in $HELM_ARCHIVES_DIR/*; do
-        resources+=($archive)
+        resources+=("$archive")
     done
 
     for binary in $BINARY_DIR/*; do
-        resources+=($binary)
+        resources+=("$binary")
     done
     echo "${resources[@]}"
 }
 
 # $1: absolute path to asset
 upload_asset() {
-    resp=$(curl --write-out %{http_code} --silent \
+    resp=$(curl --write-out '%{http_code}' --silent \
         -H "Authorization: token $GITHUB_TOKEN" \
         -H "Content-Type: $(file -b --mime-type $1)" \
         --data-binary @$1 \
@@ -67,7 +67,7 @@ upload_asset() {
     # HTTP success code expected - 201 Created
     if [[ $response_code -eq 201 ]]; then
         asset_id=$(echo $response_content | jq '.id')
-        ASSET_IDS_UPLOADED+=($asset_id)
+        ASSET_IDS_UPLOADED+=("$asset_id")
         echo "Created asset ID $asset_id successfully"
     else
         echo -e "❌ ${RED}Upload failed with response code $response_code and message \n$response_content${RESET_FMT} ❌"

--- a/scripts/validators/json-validator
+++ b/scripts/validators/json-validator
@@ -1,9 +1,19 @@
 #! /usr/bin/env bash
 
+set -euo pipefail
+
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-JSON_FILES=$(find $SCRIPTPATH/../ -name "*.json" -type f)
+JSON_FILES=$(find $SCRIPTPATH/../../ -name "*.json" -type f)
+FAILED_FILES=()
 
 for j in $JSON_FILES; do
   echo "validating $j"
-  python -mjson.tool "$j" > /dev/null || exit 1
+  python -mjson.tool "$j" > /dev/null || FAILED_FILES+=("$j")
 done
+
+if [[ ${#FAILED_FILES[@]} -eq 0 ]]; then
+  echo "✅ json-validator found no errors!"
+else
+  echo "❌ JSON syntax errors found in these files: ${FAILED_FILES[*]}"
+  exit 1
+fi

--- a/scripts/validators/readme-validator
+++ b/scripts/validators/readme-validator
@@ -1,14 +1,23 @@
 #! /usr/bin/env bash
 
+set -euo pipefail
+
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 README_FILES=$(find $SCRIPTPATH/../../ -name "*.md" -type f)
 MAX_CHAR_COUNT=25000
+FAILED_FILES=()
 
 for r in $README_FILES; do
   echo "validating $r"
   chars=$( wc -m < "$r" )
   if [[ $chars -ge $MAX_CHAR_COUNT ]]; then
-    echo "$r exceeds max character count"
-    exit 1
+    FAILED_FILES+=("$r")
   fi
 done
+
+if [[ ${#FAILED_FILES[@]} -eq 0 ]]; then
+  echo "✅ readme-validator found no errors!"
+else
+  echo "❌ README has too many characters in these files: ${FAILED_FILES[*]}"
+  exit 1
+fi

--- a/scripts/validators/release-version-validator
+++ b/scripts/validators/release-version-validator
@@ -40,14 +40,14 @@ for c in $HELM_CHART_PATH/*; do
 
         # verify version in values.yaml
         values_image_tag=$(sed -n 's/[^\s]tag: //p' $c/values.yaml | tr -d '""' | tr -d ' ')
-        if [[ $values_image_tag != $LATEST_VERSION ]]; then
+        if [[ $values_image_tag != "$LATEST_VERSION" ]]; then
             echo "❌ Please update AEMM version in $chart_name helm chart's values.yaml, image.tag field. Expected version $LATEST_VERSION, but got $values_image_tag ❌"
             UPDATE_NEEDED=true
         fi
 
         # verify version in Chart.yaml
         chart_version=$(sed -n 's/version: //p' $c/Chart.yaml)
-        if [[ $chart_version != $LATEST_VERSION ]]; then
+        if [[ $chart_version != "$LATEST_VERSION" ]]; then
             echo "❌ Please update the chart's version in $chart_name chart's Chart.yaml. Expected version $LATEST_VERSION, but got $chart_version ❌"
             UPDATE_NEEDED=true
         fi

--- a/test/e2e/cmd/static-test
+++ b/test/e2e/cmd/static-test
@@ -54,9 +54,9 @@ function test_static_metadata_with_config_file() {
 
   # Default paths should no longer be valid
   invalid_network_interface_id=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $NETWORK_INTERFACE_ID_PATH_DEFAULT)
-  assert_not_equal "invalid_network_interface_id" $NETWORK_INTERFACE_ID_DEFAULT "invalid_networkId $test_name"
+  assert_not_equal "$invalid_network_interface_id" $NETWORK_INTERFACE_ID_DEFAULT "invalid_networkId $test_name"
   invalid_ipv4_association=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $IPV4_ASSOCIATIONS_PATH_DEFAULT)
-  assert_not_equal "invalid_ipv4_association" $IPV4_ASSOCIATION_DEFAULT "invalid_ipv4Association $test_name"
+  assert_not_equal "$invalid_ipv4_association" $IPV4_ASSOCIATION_DEFAULT "invalid_ipv4Association $test_name"
 
   # Updated paths return expected
   actual_network_interface_id=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $NETWORK_INTERFACE_ID_PATH_OVERRIDDEN)

--- a/test/e2e/run-tests
+++ b/test/e2e/run-tests
@@ -13,9 +13,7 @@ SPOT_INSTANCE_ACTION_DEFAULT='terminate'
 EVENTS_DATE_REGEX='^[0-9]{1,2} [A-Z]{1}[a-z]{2} [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT'
 EVENTS_CODE_DEFAULT='system-reboot'
 EVENTS_STATE_DEFAULT='active'
-JSON_VALUE_EXTRACTION_REGEX='(\d*?,|.*[^\\]")'
 MAX_TOKEN_TTL="21600"
-EXIT_CODE_SUCCESSS=0
 EXIT_CODE_TO_RETURN=0
 STARTING_TEST_PORT=1738
 TEST_FILES=$(find $SCRIPTPATH/cmd -type f)
@@ -47,7 +45,7 @@ function health_check() {
 
 function assert_value() {
   # assert actual == expected
-  if [[ $1 == $2 ]]; then
+  if [[ $1 == "$2" ]]; then
     echo "✅ Verified $3"
   else
     echo "❌ Failed $3 verification. Actual: $1 Expected: $2"
@@ -76,7 +74,7 @@ function assert_value_within_range() {
 
 function assert_not_equal() {
   # assert actual != expected
-  if [[ $1 != $2 ]]; then
+  if [[ $1 != "$2" ]]; then
     echo "✅ Verified $3"
   else
     echo "❌ Failed $3 verification. Actual and Expected are the same value"
@@ -95,9 +93,8 @@ function assert_format() {
 }
 
 function get_value() {
-  # Extracts value from a given JSON key, $1, then removes quotes
-  # -E needed for GNU grep because passing in JSON
-  output=$(grep -Eo $1:$JSON_VALUE_EXTRACTION_REGEX <<<$2 | cut -d'"' -f 4)
+  # Extracts value from a given JSON key, $1 without quotes
+  output=$(echo $2 | jq -r 'if type=="array" then .[] else . end | .'$1'')
   if [[ $output ]]; then
     echo "$output"
   else
@@ -179,7 +176,6 @@ export EVENTS_STATE_DEFAULT
 export EVENTS_CODE_DEFAULT
 export EVENTS_DATE_REGEX
 export SPOT_DATE_REGEX
-export JSON_VALUE_EXTRACTION_REGEX
 export MAX_TOKEN_TTL
 export EXIT_CODE_TO_RETURN
 
@@ -204,7 +200,8 @@ echo "==========================================================================
 i=0
 for md_version in $(seq 1 2); do
   for test_file in $TEST_FILES; do
-    export AEMM_PORT=$(expr $i + $STARTING_TEST_PORT)
+    AEMM_PORT=$(expr $i + $STARTING_TEST_PORT)
+    export AEMM_PORT
     export METADATA_VERSION="v$md_version"
     i=$(expr $i + 1)
     $test_file

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -19,7 +19,7 @@ else
     echo "✅ goimports found no formatting errors in go source files"
 fi
 
-if grep -r -i -e 'cancelled' --exclude-dir={build,$(basename $SCRIPTPATH)} $SCRIPTPATH/../../* ; then
+if grep -r -i -e 'cancelled' --exclude-dir={build,"$(basename $SCRIPTPATH)"} $SCRIPTPATH/../../* ; then
     echo "❌ Found a misspelling of 'canceled'!"
     EXIT_CODE=3
 fi

--- a/test/helm/chart-test.sh
+++ b/test/helm/chart-test.sh
@@ -19,11 +19,17 @@ set -euo pipefail
 
 # KIND / Kubernetes
 readonly K8s_1_18="v1.18.2"
+# shellcheck disable=SC2034
 readonly K8s_1_17="v1.17.5"
+# shellcheck disable=SC2034
 readonly K8s_1_16="v1.16.9"
+# shellcheck disable=SC2034
 readonly K8s_1_15="v1.15.11"
+# shellcheck disable=SC2034
 readonly K8s_1_14="v1.14.10"
+# shellcheck disable=SC2034
 readonly K8s_1_13="v1.13.12"
+# shellcheck disable=SC2034
 readonly K8s_1_12="v1.12.10"
 KIND_IMAGE="$K8s_1_18"
 readonly KIND_VERSION="v0.8.1"
@@ -97,7 +103,7 @@ setup_ct_container() {
 
 install_kind() {
     c_echo "Installing kind..."
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/$KIND_VERSION/kind-$(uname)-amd64
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/$KIND_VERSION/kind-"$(uname)"-amd64
     chmod +x ./kind
     mv ./kind $TMP_DIR/kind
     export PATH=$TMP_DIR:$PATH
@@ -162,7 +168,7 @@ handle_errors_and_cleanup() {
 
     # error handling
     if [ $1 != "0" ]; then
-        FAILED_COMMAND=${@:2}
+        FAILED_COMMAND=${*:2}
         echo -e "\n❌ ${RED}One or more tests failed / error occurred while running command ${BOLD}${FAILED_COMMAND}${RESET_FMT} ❌"
         exit 1
     fi

--- a/test/license-test/gen-license-report.sh
+++ b/test/license-test/gen-license-report.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 BUILD_DIR="$SCRIPTPATH/../../build"
 mkdir -p $BUILD_DIR
-export PATH="$PATH:$(go env GOPATH | sed 's+:+/bin+g')/bin"
+GOBIN=$(go env GOPATH | sed 's+:+/bin+g')/bin
+export PATH="$PATH:$GOBIN"
 
 go get github.com/mitchellh/golicense
 go build -o $BUILD_DIR/aemm "$SCRIPTPATH/../../cmd"

--- a/test/shellcheck/run-shellcheck
+++ b/test/shellcheck/run-shellcheck
@@ -14,10 +14,14 @@ function exit_and_fail() {
 }
 trap exit_and_fail INT ERR TERM
 
-curl -Lo ${BUILD_DIR}/shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${KERNEL}.x86_64.tar.xz
+curl -Lo ${BUILD_DIR}/shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${KERNEL}.x86_64.tar.xz"
 tar -C ${BUILD_DIR} -xvf "${BUILD_DIR}/shellcheck.tar.xz"
 export PATH="${BUILD_DIR}/shellcheck-v${SHELLCHECK_VERSION}:$PATH"
 
-shellcheck -S error $(grep -Rn -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../ | grep ":[1-5]:" | cut -d':' -f1)
+shell_files=()
+while IFS='' read -r line; do
+   shell_files+=("$line");
+done < <(grep -Rnl -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../)
+shellcheck -S warning "${shell_files[@]}"
 
 echo "✅ All shell scripts look good! 😎"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* addressing warnings from shellcheck
* using `jq` in e2e tests bcuz we're not savages
* corrected json-validator path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
