### PR TITLE
go-report-card installation workaround

### DIFF
--- a/test/go-report-card-test/Dockerfile
+++ b/test/go-report-card-test/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1
 WORKDIR /app
 
 RUN go get github.com/gojp/goreportcard
-RUN cd $GOPATH/src/github.com/gojp/goreportcard && make install
+RUN cd $GOPATH/src/github.com/gojp/goreportcard && (make install || cd / && curl -L https://git.io/vp6lP | sh)
 
 RUN go get github.com/gojp/goreportcard/cmd/goreportcard-cli
 


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/gojp/goreportcard/pull/298

*Description of changes:*
* if `make install` fails, then fall back to manual installation

*Testing:*
* clear Docker cache and `make go-report-card-test` locally:

```
✅ goimports found no formatting errors in go source files
Grade: A+ (100.0%)
Files: 33
Issues: 0
gofmt: 100%
go_vet: 100%
golint: 100%
gocyclo: 100%
ineffassign: 100%
license: 100%
misspell: 100%
```

* Takes ~20sec longer to run now D: 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
