### PR TITLE
update git tag fetching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
-LATEST_RELEASE_TAG=$(shell git tag | tail -1)
-PREVIOUS_RELEASE_TAG=$(shell git tag | tail -2 | head -1)
+LATEST_RELEASE_TAG=$(shell git describe --tags --abbrev=0)
+PREVIOUS_RELEASE_TAG=$(shell git describe --abbrev=0 --tags `git rev-list --tags --skip=1  --max-count=1`)
 REPO_FULL_NAME=aws/amazon-ec2-metadata-mock
 IMG ?= amazon/amazon-ec2-metadata-mock
 IMG_TAG ?= ${VERSION}

--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -171,7 +171,7 @@ confirm_with_user_and_create_pr(){
     ${MAGENTA}$(git diff HEAD^ HEAD)${RESET_FMT}
 EOM
     while true; do
-        read -p "🥑${BOLD}Do you wish to create the release prep PR? Enter y/n" yn
+        read -p "🥑${BOLD}Do you wish to create the release prep PR? Enter y/n  " yn
         case $yn in
             [Yy]* ) create_pr; break;;
             [Nn]* ) rollback; exit;;

--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -33,12 +33,12 @@ USAGE=$(cat << EOM
   Usage: sync-to-aws-homebrew-tap  -r <repo> -b <binary-basename> -p <platform_pairs>
   Syncs tar.gz\'d binaries to the aws/homebrew-tap
 
-  Example: sync-to-aws-homebrew-tap -r "aws/amazon-ec2-instance-selector"
+  Example: sync-to-aws-homebrew-tap -r "aws/amazon-ec2-metadata-mock"
           Required:
-            -b          Binary basename (i.e. -b "ec2-instance-selector")
+            -b          Binary basename (i.e. -b "ec2-metadata-mock")
 
           Optional:
-            -r          Github repo to sync to in the form of "org/name"  (i.e. -r "aws/amazon-ec2-instance-selector") [DEFAULT: output of \`make repo-full-name\`]
+            -r          Github repo to sync to in the form of "org/name"  (i.e. -r "aws/amazon-ec2-metadata-mock") [DEFAULT: output of \`make repo-full-name\`]
             -v          VERSION: The application version of the docker image [DEFAULT: output of \`make version\`]
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
             -d          Dry-Run will do all steps except pushing to git and opening the sync PR


### PR DESCRIPTION
*Issue #, if available:*
* N/A, just some minor fixes/updates to release automation

*Description of changes:*
* Update how we fetch git tags
  * `v1.10.0` will break the current approach. Output of `git tag` will be:
    * v1.1.0
    * v1.10.0
    * v1.2.0
    * ... 
    * v1.9.0
  * then piping output to `tail -1` will return **v1.9.0** as the latest which is **incorrect**
* Correcting repo name in sync-homebrew
* Add spacing for PR confirmation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
