### PR TITLE
Update types.go

### DIFF
--- a/pkg/mock/dynamic/types/types.go
+++ b/pkg/mock/dynamic/types/types.go
@@ -15,19 +15,19 @@ package types
 
 // InstanceIdentityDocument structure for mock json response parsing
 type InstanceIdentityDocument struct {
-	AccountId               string `json:"accountId"`
-	ImageId                 string `json:"imageId"`
-	AvailabilityZone        string `json:"availabilityZone"`
-	RamdiskId               string `json:"ramdiskId"`
-	KernelId                string `json:"kernelId"`
-	DevpayProductCodes      string `json:"devpayProductCodes"`
-	MarketplaceProductCodes string `json:"marketplaceProductCodes"`
-	Version                 string `json:"version"`
-	PrivateIp               string `json:"privateIp"`
-	BillingProducts         string `json:"billingProducts"`
-	InstanceId              string `json:"instanceId"`
-	PendingTime             string `json:"pendingTime"`
-	Architecture            string `json:"architecture"`
-	InstanceType            string `json:"instanceType"`
-	Region                  string `json:"region"`
+	AccountId                string `json:"accountId"`
+	ImageId                  string `json:"imageId"`
+	AvailabilityZone         string `json:"availabilityZone"`
+	RamdiskId               *string `json:"ramdiskId"`
+	KernelId                *string `json:"kernelId"`
+	DevpayProductCodes      *string `json:"devpayProductCodes"`
+	MarketplaceProductCodes *string `json:"marketplaceProductCodes"`
+	Version                  string `json:"version"`
+	PrivateIp                string `json:"privateIp"`
+	BillingProducts         *string `json:"billingProducts"`
+	InstanceId               string `json:"instanceId"`
+	PendingTime              string `json:"pendingTime"`
+	Architecture             string `json:"architecture"`
+	InstanceType             string `json:"instanceType"`
+	Region                   string `json:"region"`
 }


### PR DESCRIPTION
these fields should accept null values

Issue #, if available:

aws-iam-authenticator throws a marshalling error because it expects nulls instead of empty strings on a few dynamic keys.

Description of changes:

To allow that, strings have to be changed by *strings to allow the null value on json marshalling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
