### PR TITLE
push images to public ecr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,9 @@ jobs:
 
     - name: Release Docker Linux
       run: make release-docker-linux
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     
   releaseWindows:
     name: Release Windows
@@ -113,6 +116,9 @@ jobs:
 
     - name: Release Windows Docker Image
       run: choco install make && RefreshEnv.cmd && make release-docker-windows
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   postRelease:
     name: Post Release

--- a/helm/amazon-ec2-metadata-mock/README.md
+++ b/helm/amazon-ec2-metadata-mock/README.md
@@ -170,7 +170,7 @@ The following tables lists the configurable parameters of the chart and their de
 ### General
 Parameter | Description | Default
 --- | --- | --- 
-`image.repository` | image repository | `amazon/amazon-ec2-metadata-mock` 
+`image.repository` | image repository | `public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock`
 `image.tag` | image tag | `<VERSION>` 
 `image.pullPolicy` | image pull policy | `IfNotPresent`
 `replicaCount` | defines the number of amazon-ec2-metadata-mock pods to replicate | `1`

--- a/helm/amazon-ec2-metadata-mock/values.yaml
+++ b/helm/amazon-ec2-metadata-mock/values.yaml
@@ -1,7 +1,7 @@
 # Default values to be passed into the chart's templates.
 
 image:
-  repository: "amazon/amazon-ec2-metadata-mock"
+  repository: "public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock"
   tag: "v1.8.0"
   pullPolicy: "IfNotPresent"
 

--- a/scripts/draft-release-notes
+++ b/scripts/draft-release-notes
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
+BUILD_DIR="${GIT_REPO_ROOT}/build"
+
+RELEASE_NOTES="${BUILD_DIR}/release-notes.md"
+touch "${RELEASE_NOTES}"
+
+>&2 git fetch --all --tags
+
+if git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"; then
+    LAST_RELEASE_HASH=$(git rev-list --tags --max-count=1 --skip=1 --no-walk)
+else 
+    TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
+    LAST_RELEASE_HASH=$(git rev-list -1 $TAG)
+fi
+
+echo "## Changes"  | tee -a "${RELEASE_NOTES}"
+for change in $(git rev-list $LAST_RELEASE_HASH..HEAD); do
+    one_line_msg=$(git --no-pager log --pretty='%s (thanks to %an)'  "${change}" -n1 |  sed 's/^\[.*\]//' | xargs)
+    # render markdown links for cross-posting release notes
+    pr_num=$(echo $one_line_msg | grep -Eo '(#[0-9]*)' || [[ $? == 1 ]])
+    md_link="[$pr_num](https://github.com/aws/amazon-ec2-metadata-mock/pull/${pr_num:1})"
+    echo "  - ${one_line_msg/\($pr_num\)/$md_link}" | tee -a "${RELEASE_NOTES}"
+done
+
+>&2 echo -e "\n\nRelease notes file: ${RELEASE_NOTES}"

--- a/scripts/ecr-public-login
+++ b/scripts/ecr-public-login
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR=$SCRIPTPATH/../build/
+export PATH="${BUILD_DIR}:${PATH}"
+
+if [[ -z "${ECR_REGISTRY}" ]]; then
+    echo "The env var ECR_REGISTRY must be set"
+    exit 1
+fi
+
+function exit_and_fail() {
+    echo "❌ Failed to login to ECR Public Repo!"
+}
+
+trap exit_and_fail INT TERM ERR
+
+"${SCRIPTPATH}/install-awscli"
+
+docker login --username AWS --password="$(aws ecr-public get-login-password --region us-east-1)" "${ECR_REGISTRY}"

--- a/scripts/install-awscli
+++ b/scripts/install-awscli
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR=$SCRIPTPATH/../build/
+
+VERSION="2.1.13"
+os=$(uname)
+arch=$(uname -m)
+
+function exit_and_fail() {
+    echo "❌ Unable to install awscli v${VERSION} for OS ${os} and arch ${arch}"
+}
+trap exit_and_fail INT TERM ERR
+
+if [[ "${os}" = "Linux" ]]; then
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-${arch}-${VERSION}.zip" -o "${BUILD_DIR}/awscliv2.zip"
+    unzip "${BUILD_DIR}/awscliv2.zip" -d "${BUILD_DIR}/awscliv2"
+    ${BUILD_DIR}/awscliv2/aws/install -i ${BUILD_DIR}/awscliv2 -b "${BUILD_DIR}"
+elif [[ "${os}" = "Darwin" ]]; then
+    curl "https://awscli.amazonaws.com/AWSCLIV2-${VERSION}.pkg" -o "${BUILD_DIR}/awscliv2.pkg"
+    CHOICES_XML="${BUILD_DIR}/aws-cli-mac.plist"
+    cat << EOF > "${CHOICES_XML}"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <dict>
+      <key>choiceAttribute</key>
+      <string>customLocation</string>
+      <key>attributeSetting</key>
+      <string>${BUILD_DIR}</string>
+      <key>choiceIdentifier</key>
+      <string>default</string>
+    </dict>
+  </array>
+</plist>
+EOF
+    installer -pkg ${BUILD_DIR}/awscliv2.pkg \
+        -target CurrentUserHomeDirectory \
+        -applyChoiceChangesXML "${CHOICES_XML}"
+    ln -s "${BUILD_DIR}/aws-cli/aws" "${BUILD_DIR}/aws"
+else # windows
+    choco install awscli --version ${VERSION} --force -y || :
+fi
+
+echo "✅ Install AWS CLI v${VERSION} for OS ${os} and arch ${arch}"

--- a/scripts/retag-docker-images
+++ b/scripts/retag-docker-images
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+REPO_ROOT_PATH=$SCRIPTPATH/../
+MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
+
+VERSION=$(make -s -f $MAKE_FILE_PATH version)
+PLATFORMS=("linux/amd64")
+
+
+USAGE=$(cat << 'EOM'
+  Usage: retag-docker-images  [-p <platform pairs>]
+  Tags created docker images with a new prefix
+
+  Example: retag-docker-images -p "linux/amd64,linux/arm" -o <OLD_REPO_PREFIX> -n <NEW_REPO_PREFIX>
+          Optional:
+            -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -o          OLD IMAGE REPO to retag
+            -n          NEW IMAGE REPO to tag with
+            -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
+EOM
+)
+
+# Process our input arguments
+while getopts "p:o:n:v:" opt; do
+  case ${opt} in
+    p ) # Platform Pairs
+        IFS=',' read -ra PLATFORMS <<< "$OPTARG"
+      ;;
+    o ) # Old Image Repo
+        OLD_IMAGE_REPO="$OPTARG"
+      ;;
+    n ) # New Image Repo
+        NEW_IMAGE_REPO="$OPTARG"
+      ;;
+    v ) # Image Version
+        VERSION="$OPTARG"
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+function exit_and_fail() {
+  echo "❌ Failed retagging docker images"
+}
+
+trap "exit_and_fail" INT TERM ERR
+
+for os_arch in "${PLATFORMS[@]}"; do
+    os=$(echo $os_arch | cut -d'/' -f1)
+    arch=$(echo $os_arch | cut -d'/' -f2)
+
+    old_img_tag="$OLD_IMAGE_REPO:$VERSION-$os-$arch"
+    new_img_tag="$NEW_IMAGE_REPO:$VERSION-$os-$arch"
+
+    current_os=$(uname)
+    # Windows will append '\r' to the end of $img which
+    # results in docker failing to create the manifest due to invalid reference format.
+    # However, MacOS does not recognize '\r' as carriage return
+    # and attempts to remove literal 'r' chars; therefore, made this so portable
+    if [[ $current_os != "Darwin" ]]; then
+      old_img_tag=$(echo $old_img_tag | sed -e 's/\r//')
+      new_img_tag=$(echo $new_img_tag | sed -e 's/\r//')
+    fi
+    
+    docker tag ${old_img_tag} ${new_img_tag}
+    echo "✅ Successfully retagged docker image $old_img_tag to $new_img_tag"
+done
+
+echo "✅ Done Retagging!"

--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -9,4 +9,4 @@ LICENSE_TEST_TAG="aemm-license-test"
 
 SUPPORTED_PLATFORMS_LINUX="linux/amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
 docker build --build-arg=GOPROXY=direct -t $LICENSE_TEST_TAG $SCRIPTPATH/
-docker run -it -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/aemm-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /aemm-bin/$BINARY_NAME
+docker run -i -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/aemm-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /aemm-bin/$BINARY_NAME

--- a/test/shellcheck/run-shellcheck
+++ b/test/shellcheck/run-shellcheck
@@ -21,7 +21,7 @@ export PATH="${BUILD_DIR}/shellcheck-v${SHELLCHECK_VERSION}:$PATH"
 shell_files=()
 while IFS='' read -r line; do
    shell_files+=("$line");
-done < <(grep -Rnl -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../)
+done < <(grep -Rnl --exclude-dir=build -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../)
 shellcheck -S warning "${shell_files[@]}"
 
 echo "✅ All shell scripts look good! 😎"


### PR DESCRIPTION
Issue #, if available:
* We are not currently publishing images to public ECR

Description of changes:
* Brought over Brandon's NTH ECR changes to AEMM
* Added functionality to `draft-release-notes` to markdown the PR links for cross posting

Output of draft-release-notes:

```
  - push images to public ecr (thanks to Bryan™️)
  - make fmt [#113](https://github.com/aws/amazon-ec2-metadata-mock/pull/113) (thanks to Brandon Wagner)
  - remove CLA [#114](https://github.com/aws/amazon-ec2-metadata-mock/pull/114) (thanks to Brandon Wagner)
  - Update types.go [#112](https://github.com/aws/amazon-ec2-metadata-mock/pull/112) (thanks to Julian Martinez)
  - fix docker login commands for gh actions [#111](https://github.com/aws/amazon-ec2-metadata-mock/pull/111) (thanks to Brandon Wagner)
  - pr template [#110](https://github.com/aws/amazon-ec2-metadata-mock/pull/110) (thanks to Brandon Wagner)
  - gh actions [#109](https://github.com/aws/amazon-ec2-metadata-mock/pull/109) (thanks to Brandon Wagner)

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
