### PR TITLE
CI Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ sync-readme-to-dockerhub:
 	${MAKEFILE_PATH}/scripts/sync-readme-to-dockerhub
 
 sync-readme-to-ecr-public:
-	#@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
+	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
 	${MAKEFILE_PATH}/scripts/sync-readme-to-ecr-public
 
 homebrew-sync-dry-run:

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,10 @@ push-docker-images-windows:
 sync-readme-to-dockerhub:
 	${MAKEFILE_PATH}/scripts/sync-readme-to-dockerhub
 
+sync-readme-to-ecr-public:
+	#@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
+	${MAKEFILE_PATH}/scripts/sync-readme-to-ecr-public
+
 homebrew-sync-dry-run:
 	${MAKEFILE_PATH}/scripts/sync-to-aws-homebrew-tap -d -b ${BINARY_NAME} -r ${REPO_FULL_NAME} -p ${SUPPORTED_PLATFORMS_LINUX} -v ${LATEST_RELEASE_TAG}
 
@@ -137,7 +141,7 @@ validate-release-version:
 
 release-github: build-release-assets upload-resources-to-github
 
-release-docker-linux: build-docker-images-linux push-docker-images-linux sync-readme-to-dockerhub
+release-docker-linux: build-docker-images-linux push-docker-images-linux sync-readme-to-dockerhub sync-readme-to-ecr-public
 
 release-docker-windows: build-docker-images-windows push-docker-images-windows
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@
    <a href="https://opensource.org/licenses/Apache-2.0">
    <img src="https://img.shields.io/badge/License-Apache%202.0-ff69b4.svg?color=orange" alt="license">
    </a>
-   <a href="https://travis-ci.org/aws/amazon-ec2-metadata-mock">
-   <img src="https://travis-ci.org/aws/amazon-ec2-metadata-mock.svg?branch=main" alt="build-status">
-   </a>
    <a href="https://hub.docker.com/r/amazon/amazon-ec2-metadata-mock">
    <img src="https://img.shields.io/docker/pulls/amazon/amazon-ec2-metadata-mock" alt="docker-pulls">
    </a>
 </p>
+
+![EC2 Metadata Mock CI and Release](https://github.com/aws/amazon-ec2-metadata-mock/workflows/EC2%20Metadata%20Mock%20CI%20and%20Release/badge.svg)
 
 # Table of Contents
 

--- a/scripts/sync-readme-to-ecr-public
+++ b/scripts/sync-readme-to-ecr-public
@@ -13,13 +13,13 @@ A complete version of the ReadMe can be found [here](https://github.com/aws/amaz
 
 
 if git --no-pager diff --name-only HEAD^ HEAD | grep 'README.md'; then
-    # converting to json to insert esc chars, then replace newlines for proper markdown render
+    #converting to json to insert esc chars, then replace newlines for proper markdown render
     raw_about=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" '{"usageText": $msg}' | jq '.usageText' | sed 's/\\n/\
 /g')
     char_to_trunc="$(($MAX_CHAR_COUNT-${#ADDITIONAL_MSG}))"
     raw_truncated="${raw_about:0:$char_to_trunc}"
     raw_truncated+="$ADDITIONAL_MSG"
-    resp=$(aws ecr-public put-repository-catalog-data --repository-name="${REPO_NAME}" --catalog-data aboutText="${raw_truncated}",usageText="${USAGE_TEXT}")
+    resp=$(aws ecr-public put-repository-catalog-data --repository-name="${REPO_NAME}" --catalog-data aboutText="${raw_truncated}",usageText="${USAGE_TEXT}" --region us-east-1)
 
     if [[ $resp -ge 1 ]]; then
         echo "README sync to ecr-public failed"

--- a/scripts/sync-readme-to-ecr-public
+++ b/scripts/sync-readme-to-ecr-public
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+REPO_NAME="amazon-ec2-metadata-mock"
+#about and usage section char max
+MAX_CHAR_COUNT=10240
+USAGE_TEXT="See About section"
+ADDITIONAL_MSG="...
+
+**truncated due to char limits**...
+A complete version of the ReadMe can be found [here](https://github.com/aws/amazon-ec2-metadata-mock#amazon-ec2-metadata-mock)\""
+
+
+if git --no-pager diff --name-only HEAD^ HEAD | grep 'README.md'; then
+    # converting to json to insert esc chars, then replace newlines for proper markdown render
+    raw_about=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" '{"usageText": $msg}' | jq '.usageText' | sed 's/\\n/\
+/g')
+    char_to_trunc="$(($MAX_CHAR_COUNT-${#ADDITIONAL_MSG}))"
+    raw_truncated="${raw_about:0:$char_to_trunc}"
+    raw_truncated+="$ADDITIONAL_MSG"
+    resp=$(aws ecr-public put-repository-catalog-data --repository-name="${REPO_NAME}" --catalog-data aboutText="${raw_truncated}",usageText="${USAGE_TEXT}")
+
+    if [[ $resp -ge 1 ]]; then
+        echo "README sync to ecr-public failed"
+        exit 1
+    else
+        echo "README sync to ecr-public succeeded!"
+    fi
+else
+    echo "README.md did not change in the last commit. Not taking any action."
+fi


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
* Keep ReadMe NSYNC with ecr public repo
* Add make target to release process
* Update CI badging

Testing:
* `make sync-readme-to-ecr-public` 
* see updated ecr repo docs: https://gallery.ecr.aws/aws-ec2/amazon-ec2-metadata-mock

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
