### PR TITLE
fix(capitalization): namespace is rendered empty

### DIFF
--- a/helm/amazon-ec2-metadata-mock/templates/service.yaml
+++ b/helm/amazon-ec2-metadata-mock/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.serviceName }}
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "amazon-ec2-metadata-mock.labels" . | indent 4 }}
 spec:


### PR DESCRIPTION
Please see this stack overflow for more information.
https://stackoverflow.com/questions/51760772/why-is-release-namespace-rendered-empty

Description of changes:
`namespace` -> `Namespace`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
