### PR TITLE
feat(rebalance): must return 404 when no rebalance signal configured

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ release-docker-windows: build-docker-images-windows push-docker-images-windows
 
 release: release-github release-docker-linux release-docker-windows
 
-# Targets intended for local use 
+# Targets intended for local use
 fmt:
 	goimports -w ./ && gofmt -s -w ./
 
@@ -192,4 +192,4 @@ release-prep-custom: # Run make NEW_VERSION=v1.2.3 release-prep-custom to prep f
 ifdef NEW_VERSION
 	$(shell echo "${MAKEFILE_PATH}/scripts/create-local-tag-for-release -v $(NEW_VERSION) && echo && make create-release-prep-pr")
 endif
-	
+

--- a/pkg/mock/spot/spot.go
+++ b/pkg/mock/spot/spot.go
@@ -106,12 +106,14 @@ func handleSpotITN(res http.ResponseWriter, req *http.Request) {
 }
 
 func handleRebalance(res http.ResponseWriter, req *http.Request) {
-	// default time to requestTime, unless overridden
-	mockResponseTime := time.Now().UTC().Format(time.RFC3339)
 	if c.SpotConfig.RebalanceRecTime != "" {
-		mockResponseTime = c.SpotConfig.RebalanceRecTime
+		mockResponseTime := c.SpotConfig.RebalanceRecTime
+		server.FormatAndReturnJSONResponse(res, t.RebalanceRecommendationResponse{NoticeTime: mockResponseTime})
+	} else {
+		log.Printf("No Response time given.\n")
+		server.ReturnNotFoundResponse(res)
+		return
 	}
-	server.FormatAndReturnJSONResponse(res, t.RebalanceRecommendationResponse{NoticeTime: mockResponseTime})
 }
 
 func getInstanceActionResponse(time string) t.InstanceActionResponse {


### PR DESCRIPTION
# Description of changes:

according to the documentation, if the signal has not been emitted for the instance, events/recommendations/rebalance is not present and you receive an HTTP 404 error when you try to retrieve it.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/rebalance-recommendations.html\#cp-instance-metadata

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
