### PR TITLE
add delay parity to Reblance Rec

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,18 @@ Available Commands:
   spot        Mock EC2 Spot interruption notice
 
 Flags:
-  -c, --config-file string         config file for cli input parameters in json format (default: $HOME/aemm-config.json)
-  -h, --help                       help for ec2-metadata-mock
-  -n, --hostname string            the HTTP hostname for the mock url (default: 0.0.0.0)
-  -I, --imdsv2                     whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
-  -d, --mock-delay-sec int         mock delay in seconds, relative to the application start time (default: 0 seconds)
-  -x, --mock-ip-count int          number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
-      --mock-trigger-time string   mock trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
-  -p, --port string                the HTTP port where the mock runs (default: 1338)
-  -s, --save-config-to-file        whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
-      --version                    version for ec2-metadata-mock
+  -c, --config-file string              config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -h, --help                            help for ec2-metadata-mock
+  -n, --hostname string                 the HTTP hostname for the mock url (default: 0.0.0.0)
+  -I, --imdsv2                          whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int              spot itn delay in seconds, relative to the application start time (default: 0 seconds)
+  -x, --mock-ip-count int               number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
+      --mock-trigger-time string        spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
+  -p, --port string                     the HTTP port where the mock runs (default: 1338)
+      --rebalance-delay-sec int         rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
+      --rebalance-trigger-time string   rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
+  -s, --save-config-to-file             whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+      --version                         version for ec2-metadata-mock
 
 Use "ec2-metadata-mock [command] --help" for more information about a command.
 ```
@@ -281,15 +283,16 @@ Flags:
   -t, --time string                    termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
-  -c, --config-file string         config file for cli input parameters in json format (default: $HOME/aemm-config.json)
-  -h, --help                       help for ec2-metadata-mock
-  -n, --hostname string            the HTTP hostname for the mock url (default: 0.0.0.0)
-  -I, --imdsv2                     whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
-  -d, --mock-delay-sec int         mock delay in seconds, relative to the application start time (default: 0 seconds)
-  -x, --mock-ip-count int          number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
-      --mock-trigger-time string   mock trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
-  -p, --port string                the HTTP port where the mock runs (default: 1338)
-  -s, --save-config-to-file        whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+  -c, --config-file string              config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -n, --hostname string                 the HTTP hostname for the mock url (default: 0.0.0.0)
+  -I, --imdsv2                          whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int              spot itn delay in seconds, relative to the application start time (default: 0 seconds)
+  -x, --mock-ip-count int               number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
+      --mock-trigger-time string        spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
+  -p, --port string                     the HTTP port where the mock runs (default: 1338)
+      --rebalance-delay-sec int         rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
+      --rebalance-trigger-time string   rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
+  -s, --save-config-to-file             whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
 ```
 
 1.) **Starting AEMM with `spot`**:  `spot` routes available immediately:

--- a/pkg/cmd/root/globalflags/globalflags.go
+++ b/pkg/cmd/root/globalflags/globalflags.go
@@ -21,10 +21,10 @@ const (
 	// SaveConfigToFileFlag - whether to save processed config from all input sources
 	SaveConfigToFileFlag = "save-config-to-file"
 
-	// MockDelayInSecFlag - mock delay in seconds, relative to the application start time
+	// MockDelayInSecFlag - spot itn delay in seconds, relative to the application start time
 	MockDelayInSecFlag = "mock-delay-sec"
 
-	// MockTriggerTimeFlag - mock trigger time in RFC3339
+	// MockTriggerTimeFlag - spot itn trigger time in RFC3339
 	MockTriggerTimeFlag = "mock-trigger-time"
 
 	// MockIPCountFlag - the number of nodes in a cluster that can receive Spot ITNs
@@ -38,9 +38,15 @@ const (
 
 	// Imdsv2Flag - whether to enable IMDSv2 only requiring a session token when submitting requests
 	Imdsv2Flag = "imdsv2"
+
+	// RebalanceDelayInSecFlag - rebalance rec delay in seconds, relative to the application start time
+	RebalanceDelayInSecFlag = "rebalance-delay-sec"
+
+	// RebalanceTriggerTimeFlag - rebalance rec trigger time in RFC3339
+	RebalanceTriggerTimeFlag = "rebalance-trigger-time"
 )
 
 // GetTopLevelFlags returns the top level global flags
 func GetTopLevelFlags() []string {
-	return []string{ConfigFileFlag, SaveConfigToFileFlag, MockDelayInSecFlag, MockTriggerTimeFlag, MockIPCountFlag, Imdsv2Flag}
+	return []string{ConfigFileFlag, SaveConfigToFileFlag, MockDelayInSecFlag, MockTriggerTimeFlag, MockIPCountFlag, Imdsv2Flag, RebalanceDelayInSecFlag, RebalanceTriggerTimeFlag}
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -40,12 +40,14 @@ var (
 	cfgMdPrefix = cfg.GetCfgMdValPrefix()
 	cfgDnPrefix = cfg.GetCfgDnValPrefix()
 	defaultCfg  = map[string]interface{}{
-		gf.ConfigFileFlag:       cfg.GetDefaultCfgFileName(),
-		gf.MockDelayInSecFlag:   0,
-		gf.MockTriggerTimeFlag:  "",
-		gf.MockIPCountFlag:      2,
-		gf.SaveConfigToFileFlag: false,
-		gf.Imdsv2Flag:           false,
+		gf.ConfigFileFlag:           cfg.GetDefaultCfgFileName(),
+		gf.MockDelayInSecFlag:       0,
+		gf.MockTriggerTimeFlag:      "",
+		gf.MockIPCountFlag:          2,
+		gf.SaveConfigToFileFlag:     false,
+		gf.Imdsv2Flag:               false,
+		gf.RebalanceDelayInSecFlag:  0,
+		gf.RebalanceTriggerTimeFlag: "",
 	}
 )
 
@@ -78,10 +80,12 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringP(gf.PortFlag, "p", "", "the HTTP port where the mock runs (default: 1338)")
 	cmd.PersistentFlags().StringP(gf.ConfigFileFlag, "c", "", "config file for cli input parameters in json format (default: "+cfg.GetDefaultCfgFileName()+")")
 	cmd.PersistentFlags().BoolP(gf.SaveConfigToFileFlag, "s", false, "whether to save processed config from all input sources in "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
-	cmd.PersistentFlags().Int64P(gf.MockDelayInSecFlag, "d", 0, "mock delay in seconds, relative to the application start time (default: 0 seconds)")
-	cmd.PersistentFlags().String(gf.MockTriggerTimeFlag, "", "mock trigger time in RFC3339 format. This takes priority over "+gf.MockDelayInSecFlag+" (default: none)")
+	cmd.PersistentFlags().Int64P(gf.MockDelayInSecFlag, "d", 0, "spot itn delay in seconds, relative to the application start time (default: 0 seconds)")
+	cmd.PersistentFlags().String(gf.MockTriggerTimeFlag, "", "spot itn trigger time in RFC3339 format. This takes priority over "+gf.MockDelayInSecFlag+" (default: none)")
 	cmd.PersistentFlags().Int64P(gf.MockIPCountFlag, "x", 2, "number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event")
 	cmd.PersistentFlags().BoolP(gf.Imdsv2Flag, "I", false, "whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)")
+	cmd.PersistentFlags().Int64(gf.RebalanceDelayInSecFlag, 0, "rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)")
+	cmd.PersistentFlags().String(gf.RebalanceTriggerTimeFlag, "", "rebalance rec trigger time in RFC3339 format. This takes priority over "+gf.RebalanceDelayInSecFlag+" (default: none)")
 
 	// add subcommands
 	cmd.AddCommand(spot.Command, events.Command)

--- a/pkg/cmd/root/root_test.go
+++ b/pkg/cmd/root/root_test.go
@@ -31,7 +31,7 @@ func TestNewCmdName(t *testing.T) {
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for root command to be %s, but was %s", expected, actual))
 }
 func TestNewCmdFlags(t *testing.T) {
-	expectedFlags := []string{"config-file", "save-config-to-file", "mock-delay-sec", "mock-trigger-time", "mock-ip-count", "hostname", "port", "imdsv2"}
+	expectedFlags := []string{"config-file", "save-config-to-file", "mock-delay-sec", "mock-trigger-time", "mock-ip-count", "hostname", "port", "imdsv2", "rebalance-delay-sec", "rebalance-trigger-time"}
 
 	cmd := NewCmd()
 	actualFlagSet := cmd.PersistentFlags()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -27,13 +27,15 @@ type Config struct {
 
 	// ----- CLI config ----- //
 	// config keys that are also cli flags
-	CfgFile          string `mapstructure:"config-file"`
-	MockDelayInSec   int64  `mapstructure:"mock-delay-sec"`
-	MockTriggerTime  string `mapstructure:"mock-trigger-time"`
-	MockIPCount      int    `mapstructure:"mock-ip-count"`
-	SaveConfigToFile bool   `mapstructure:"save-config-to-file"`
-	Server           Server `mapstructure:"server"`
-	Imdsv2Required   bool   `mapstructure:"imdsv2"`
+	CfgFile              string `mapstructure:"config-file"`
+	MockDelayInSec       int64  `mapstructure:"mock-delay-sec"`
+	MockTriggerTime      string `mapstructure:"mock-trigger-time"`
+	MockIPCount          int    `mapstructure:"mock-ip-count"`
+	SaveConfigToFile     bool   `mapstructure:"save-config-to-file"`
+	Server               Server `mapstructure:"server"`
+	Imdsv2Required       bool   `mapstructure:"imdsv2"`
+	RebalanceDelayInSec  int64  `mapstructure:"rebalance-delay-sec"`
+	RebalanceTriggerTime string `mapstructure:"rebalance-trigger-time"`
 
 	// config keys for subcommands
 	SpotConfig   spot.Config   `mapstructure:"spot"`

--- a/pkg/mock/spot/spot.go
+++ b/pkg/mock/spot/spot.go
@@ -49,7 +49,6 @@ func SetConfig(config cfg.Config) {
 
 // Handler processes http requests
 func Handler(res http.ResponseWriter, req *http.Request) {
-	log.Printf("RemoteAddr: %s sent request to mock spot interruption: %s\n", req.URL.Path, req.RemoteAddr)
 	// specify negative value to disable this feature
 	if c.MockIPCount >= 0 {
 		// req.RemoteAddr is formatted as IP:port
@@ -78,7 +77,7 @@ func handleSpotITN(res http.ResponseWriter, req *http.Request) {
 		triggerTime, _ := time.Parse(time.RFC3339, c.MockTriggerTime)
 		delayRemaining := triggerTime.Unix() - requestTime
 		if delayRemaining > 0 {
-			log.Printf("MockTriggerTime %s was not reached yet. The mock response will be available in %ds. Returning `notFoundResponse` for now", triggerTime, delayRemaining)
+			log.Printf("MockTriggerTime %s was not reached yet. The spot itn will be available in %ds. Returning `notFoundResponse` for now", triggerTime, delayRemaining)
 			server.ReturnNotFoundResponse(res)
 			return
 		}
@@ -86,7 +85,7 @@ func handleSpotITN(res http.ResponseWriter, req *http.Request) {
 		delayInSeconds := c.MockDelayInSec
 		delayRemaining := delayInSeconds - (requestTime - spotItnStartTime)
 		if delayRemaining > 0 {
-			log.Printf("Delaying the response by %ds as requested. The mock response will be available in %ds. Returning `notFoundResponse` for now", delayInSeconds, delayRemaining)
+			log.Printf("Delaying the response by %ds as requested. The spot itn will be available in %ds. Returning `notFoundResponse` for now", delayInSeconds, delayRemaining)
 			server.ReturnNotFoundResponse(res)
 			return
 		}
@@ -106,6 +105,24 @@ func handleSpotITN(res http.ResponseWriter, req *http.Request) {
 }
 
 func handleRebalance(res http.ResponseWriter, req *http.Request) {
+	requestTime := time.Now().Unix()
+	if c.RebalanceTriggerTime != "" {
+		triggerTime, _ := time.Parse(time.RFC3339, c.RebalanceTriggerTime)
+		delayRemaining := triggerTime.Unix() - requestTime
+		if delayRemaining > 0 {
+			log.Printf("RebalanceTriggerTime %s was not reached yet. The rebalance rec will be available in %ds. Returning `notFoundResponse` for now", triggerTime, delayRemaining)
+			server.ReturnNotFoundResponse(res)
+			return
+		}
+	} else {
+		delayInSeconds := c.RebalanceDelayInSec
+		delayRemaining := delayInSeconds - (requestTime - spotItnStartTime)
+		if delayRemaining > 0 {
+			log.Printf("Delaying the response by %ds as requested. The rebalance rec will be available in %ds. Returning `notFoundResponse` for now", delayInSeconds, delayRemaining)
+			server.ReturnNotFoundResponse(res)
+			return
+		}
+	}
 	// default time to requestTime, unless overridden
 	mockResponseTime := time.Now().UTC().Format(time.RFC3339)
 	if c.SpotConfig.RebalanceRecTime != "" {

--- a/test/e2e/cmd/spot-test
+++ b/test/e2e/cmd/spot-test
@@ -11,7 +11,8 @@ ENV_OVERRIDDEN_INSTANCE_ACTION="stop"
 FLAG_OVERRIDDEN_TERMINATION_TIME="2025-05-05T05:05:55Z"
 CONFIG_OVERRIDDEN_TERMINATION_TIME="2020-01-07T01:03:47Z"
 FLAG_OVERRIDDEN_NOTICE_TIME="2010-10-26T11:11:11Z"
-SPOT_DELAY=4
+SPOT_DELAY=10
+REBALANCE_DELAY=5
 
 function test_spot_paths() {
   pid=$1
@@ -160,6 +161,45 @@ function test_spot_times_overrides() {
   clean_up $pid
 }
 
+function test_spot_and_rebalance_delay() {
+  pid=$1
+  spot_delay_in_sec=$2
+  rebalance_delay_in_sec=$3
+  tput setaf $MAGENTA
+  health_check "http://$HOSTNAME:$AEMM_PORT"
+  TOKEN=$(get_v2Token $MAX_TOKEN_TTL $AEMM_PORT)
+
+  # spotItn + rebalanceRec are both affected by delay
+  expected_delayed_response=$(cat $SCRIPTPATH/golden/404_response.golden)
+  spot_response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOT_IA_TEST_PATH)
+  assert_value "$spot_response" "$expected_delayed_response" "test_spot_and_rebalance_delay::spot-delay_response"
+  rrn_response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $RRN_TEST_PATH)
+  assert_value "$rrn_response" "$expected_delayed_response" "test_spot_and_rebalance_delay::rebalance-delay_response"
+
+  # test assumes spot delay is greater for simplicity and real world simulation
+  echo "⏲ Waiting on spot delay ⏲"
+  sleep $spot_delay_in_sec
+  spot_response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $SPOT_IA_TEST_PATH)
+  assert_not_equal "$spot_response" "$expected_delayed_response" "test_spot_and_rebalance_delay::spot-post-delay_response"
+
+  delay_remaining="$(($spot_delay_in_sec-$rebalance_delay_in_sec))"
+
+  echo "⏲ Waiting on rebalance delay ⏲"
+  sleep $delay_remaining
+  rrn_response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $RRN_TEST_PATH)
+  assert_not_equal "$rrn_response" "$expected_delayed_response" "test_spot_and_rebalance_delay::rebalance-post-delay_response"
+
+  # Confirm responses aren't empty
+  if [[ ! -z $spot_response ]] && [[ ! -z $rrn_response ]]; then
+    echo "✅ Verified post-delay response"
+  else
+    echo "❌ Failed delay: there should be a response after delay"
+    EXIT_CODE_TO_RETURN=1
+  fi
+
+  clean_up $pid
+}
+
 tput setaf $MAGENTA
 echo "======================================================================================================"
 echo "🥑 Starting spot integration tests $METADATA_VERSION"
@@ -239,5 +279,11 @@ $start_cmd &
 SPOT_PID=$!
 test_spot_times_overrides $SPOT_PID $FLAG_OVERRIDDEN_TERMINATION_TIME $AEMM_SPOT_REBALANCE_REC_TIME
 unset AEMM_SPOT_REBALANCE_REC_TIME
+
+# rebalance delay + mock delay
+start_cmd=$(create_cmd $METADATA_VERSION spot --port $AEMM_PORT --mock-delay-sec $SPOT_DELAY --rebalance-delay-sec $REBALANCE_DELAY)
+$start_cmd &
+SPOT_PID=$!
+test_spot_and_rebalance_delay $SPOT_PID $SPOT_DELAY $REBALANCE_DELAY
 
 exit $EXIT_CODE_TO_RETURN

--- a/test/e2e/testdata/output/aemm-config-used.json
+++ b/test/e2e/testdata/output/aemm-config-used.json
@@ -27,9 +27,9 @@
   },
   "events": {
     "code": "system-reboot",
-    "not-after": "2021-02-16T16:42:04-06:00",
-    "not-before": "2021-02-09T16:42:04-06:00",
-    "not-before-deadline": "2021-02-18T16:42:04-06:00",
+    "not-after": "2021-05-17T16:22:30-05:00",
+    "not-before": "2021-05-10T16:22:30-05:00",
+    "not-before-deadline": "2021-05-19T16:22:30-05:00",
     "state": "active"
   },
   "imdsv2": false,
@@ -179,6 +179,8 @@
   "mock-delay-sec": 0,
   "mock-ip-count": 2,
   "mock-trigger-time": "",
+  "rebalance-delay-sec": 0,
+  "rebalance-trigger-time": "",
   "save-config-to-file": true,
   "server": {
     "hostname": "0.0.0.0",


### PR DESCRIPTION
Issue #, if available: #123

Description of changes:
* Users can now simulate a `404` until Rebalance Recommendation becomes "available" using `--rebalance-delay-sec` or `rebalance-trigger-time`
  * this functionality existed for Spot ITN, but not Rebalance
* updated tests
* 🌪 🌪 🌪 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
