### PR TITLE
Remove aws cli installation from ecr public script

### DIFF
--- a/scripts/ecr-public-login
+++ b/scripts/ecr-public-login
@@ -16,6 +16,4 @@ function exit_and_fail() {
 
 trap exit_and_fail INT TERM ERR
 
-"${SCRIPTPATH}/install-awscli"
-
 docker login --username AWS --password="$(aws ecr-public get-login-password --region us-east-1)" "${ECR_REGISTRY}"


### PR DESCRIPTION
Github Actions comes with aws cli out of the box. The version should support ecr public apis now

Issue #, if available: N/A -- release failing when trying to install aws cli

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
