### PR TITLE
Release improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: EC2 Metadata Mock CI and Release
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  # Run M-F at 5AM CDT
+  schedule:
+    - cron: '0 10 * * 1-5'
 
 env:
   DEFAULT_GO_VERSION: ^1.16
@@ -16,7 +22,7 @@ jobs:
 
   buildAndTest:
     # Not necessary to run buildAndTest targets during release
-    if: !contains(github.ref, 'refs/tags/')
+    if: ${{ !contains(github.ref, 'refs/tags/') }}
     name: Build and Test
     runs-on: ubuntu-20.04
     steps:
@@ -69,7 +75,7 @@ jobs:
 
   buildWindows:
     # Not necessary to run build targets during release
-    if: !contains(github.ref, 'refs/tags/')
+    if: ${{ !contains(github.ref, 'refs/tags/') }}
     name: Build Docker Images Windows
     runs-on: windows-2019
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ env:
 jobs:
 
   buildAndTest:
+    # Not necessary to run buildAndTest targets during release
+    if: !contains(github.ref, 'refs/tags/')
     name: Build and Test
     runs-on: ubuntu-20.04
     steps:
@@ -66,6 +68,8 @@ jobs:
       run: make build-docker-images-linux
 
   buildWindows:
+    # Not necessary to run build targets during release
+    if: !contains(github.ref, 'refs/tags/')
     name: Build Docker Images Windows
     runs-on: windows-2019
     steps:
@@ -83,7 +87,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
-    needs: [buildAndTest]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - name: Set up Go 1.x
@@ -110,7 +113,6 @@ jobs:
   releaseWindows:
     name: Release Windows
     runs-on: windows-2019
-    needs: [buildAndTest, buildWindows]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - name: Set up Go 1.x

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ validate-release-version:
 
 release-github: build-release-assets upload-resources-to-github
 
-release-docker-linux: build-docker-images-linux push-docker-images-linux sync-readme-to-dockerhub sync-readme-to-ecr-public
+release-docker-linux: build-docker-images-linux push-docker-images-linux sync-readme-to-ecr-public
 
 release-docker-windows: build-docker-images-windows push-docker-images-windows
 

--- a/scripts/sync-readme-to-ecr-public
+++ b/scripts/sync-readme-to-ecr-public
@@ -11,22 +11,17 @@ ADDITIONAL_MSG="...
 **truncated due to char limits**...
 A complete version of the ReadMe can be found [here](https://github.com/aws/amazon-ec2-metadata-mock#amazon-ec2-metadata-mock)\""
 
-
-if git --no-pager diff --name-only HEAD^ HEAD | grep 'README.md'; then
-    #converting to json to insert esc chars, then replace newlines for proper markdown render
-    raw_about=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" '{"usageText": $msg}' | jq '.usageText' | sed 's/\\n/\
+# converting to json to insert esc chars, then replace newlines for proper markdown render
+raw_about=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" '{"usageText": $msg}' | jq '.usageText' | sed 's/\\n/\
 /g')
-    char_to_trunc="$(($MAX_CHAR_COUNT-${#ADDITIONAL_MSG}))"
-    raw_truncated="${raw_about:0:$char_to_trunc}"
-    raw_truncated+="$ADDITIONAL_MSG"
-    resp=$(aws ecr-public put-repository-catalog-data --repository-name="${REPO_NAME}" --catalog-data aboutText="${raw_truncated}",usageText="${USAGE_TEXT}" --region us-east-1)
+char_to_trunc="$(($MAX_CHAR_COUNT-${#ADDITIONAL_MSG}))"
+raw_truncated="${raw_about:0:$char_to_trunc}"
+raw_truncated+="$ADDITIONAL_MSG"
+resp=$(aws ecr-public put-repository-catalog-data --repository-name="${REPO_NAME}" --catalog-data aboutText="${raw_truncated}",usageText="${USAGE_TEXT}" --region us-east-1)
 
-    if [[ $resp -ge 1 ]]; then
-        echo "README sync to ecr-public failed"
-        exit 1
-    else
-        echo "README sync to ecr-public succeeded!"
-    fi
+if [[ $resp -ge 1 ]]; then
+    echo "README sync to ecr-public failed"
+    exit 1
 else
-    echo "README.md did not change in the last commit. Not taking any action."
+    echo "README sync to ecr-public succeeded!"
 fi

--- a/scripts/sync-readme-to-ecr-public
+++ b/scripts/sync-readme-to-ecr-public
@@ -17,11 +17,6 @@ raw_about=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" '{"usageText": $msg}'
 char_to_trunc="$(($MAX_CHAR_COUNT-${#ADDITIONAL_MSG}))"
 raw_truncated="${raw_about:0:$char_to_trunc}"
 raw_truncated+="$ADDITIONAL_MSG"
-resp=$(aws ecr-public put-repository-catalog-data --repository-name="${REPO_NAME}" --catalog-data aboutText="${raw_truncated}",usageText="${USAGE_TEXT}" --region us-east-1)
+aws ecr-public put-repository-catalog-data --repository-name="${REPO_NAME}" --catalog-data aboutText="${raw_truncated}",usageText="${USAGE_TEXT}" --region us-east-1
 
-if [[ $resp -ge 1 ]]; then
-    echo "README sync to ecr-public failed"
-    exit 1
-else
-    echo "README sync to ecr-public succeeded!"
-fi
+echo "README sync to ecr-public succeeded!"


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
* Stop syncing ReadMe to DockerHub; leave script for now
* Always sync ReadMe to ECR Public on release
* Do not run Build/Test jobs during release
* Add a periodic to run jobs
  *  Currently set to Mon-Fri at 10AM UTC, which is 5AM CDT

Tested on private repo:
  *  ✅    buildAndTest did **not** run on release
  *  ✅    set periodic to every 6 minutes and saw job scheduled

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
