### PR TITLE
update PATH to fix windows build

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -21,7 +21,7 @@ SHELL ["cmd", "/S", "/C"]
 # Install Chocolatey
 RUN @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
 # Update Path
-RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows;C:\Windows\system32;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;"
+RUN RefreshEnv.cmd
 
 # New Powershell, so choco is available
 SHELL ["powershell"]
@@ -33,7 +33,7 @@ RUN choco install git -y
 RUN choco install python3 -y --params "/InstallDir:C:\Python3"
 # Update Path; need to append C:\Windows\system32 to the end to give GitBash find priority
 SHELL ["cmd", "/S", "/C"]
-RUN setx /M PATH "C:\gopath\bin;C:\go\bin;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\usr\bin;C:\Python3;C:\Windows\system32"
+RUN setx /M PATH "C:\Program Files\Go\bin;C:\go\bin;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Users\ContainerAdministrator\AppData\Local\Microsoft\WindowsApps;C:\ProgramData\chocolatey\bin;C:\Program Files\Git\bin;C:\Program Files\Git\usr\bin;C:\Python3;C:\Windows\system32;"
 
 # Build
 COPY . .


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
* Had to update PATH after upgrading to go1.17
* In addition to Go bin changing, `Git` also installed some tools in different directories (not sure when this was introduced), so needed to add that to the PATH as well
  * ex: `Git/bin` contains *bash* and *git*
    * if I do not add this path, then build fails with unknown command 'bash'
  * ex: `Git/usr/bin` contains *base64*, *ls*, *mkdir*, etc.

Testing:
![Alt Text](https://thumbs.gfycat.com/WebbedFlimsyDunlin-size_restricted.gif)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
