### PR TITLE
Replace github upload with action

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -2,6 +2,8 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - main
     tags-ignore:
       - "v*.*.*"
   pull_request:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -34,8 +33,20 @@ jobs:
       - name: Validate Release Version
         run: make validate-release-version
 
-      - name: Github Release
-        run: make release-github
+      - name: Set Release Version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Build Artifacts
+        run: make build-release-assets
+
+      - name: Upload Artifacts to GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            build/bin/*
+            build/k8s-resources/${{ env.RELEASE_VERSION }}/individual-resources.tar
+            build/k8s-resources/${{ env.RELEASE_VERSION }}/all-resources.yaml
+            build/k8s-resources/${{ env.RELEASE_VERSION }}/helm-chart-archives/*
 
       - name: Release Docker Linux
         run: make release-docker-linux
@@ -47,7 +58,6 @@ jobs:
   releaseWindows:
     name: Release Windows
     runs-on: windows-2019
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -68,7 +78,6 @@ jobs:
     name: Post Release
     runs-on: ubuntu-20.04
     needs: [release, releaseWindows]
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -86,7 +95,6 @@ jobs:
     name: Helm Lint Test
     runs-on: ubuntu-20.04
     needs: [release, releaseWindows]
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Circumvent our upload script; will remove later once this is stable
* Link to action repo: https://github.com/softprops/action-gh-release 

Testing:
* tested in private repo; works well

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
