### PR TITLE
Fix and Update Helm Chart Tests

### DIFF
--- a/.github/workflows/helm-chart-test.yaml
+++ b/.github/workflows/helm-chart-test.yaml
@@ -1,0 +1,25 @@
+name: Helm Chart Tests
+
+on:
+  schedule:
+    - # Run M-F at 5AM CDT
+    - cron: '0 10 * * 1-5'
+
+jobs:
+  chartTests:
+    name: Helm Chart Tests
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        k8sVersion: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Helm Chart Tests
+        run: test/helm/chart-test.sh -i -k ${{ matrix.k8sVersion }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,26 +106,3 @@ jobs:
 
       - name: Helm Lint Test
         run: make validate-release-version
-
-  chartTests:
-    name: Helm Chart Tests
-    runs-on: ubuntu-20.04
-    needs: [release, releaseWindows]
-    # Skip running this stage when updating release versions as part of release prep
-    # as the new Docker image wouldn't be available yet and previous commits should have already been tested.
-    # Since the release prep commit will be the release commit, always run this stage when a new tag is pushed, as part of a release.
-    if: ${{ !contains(github.event.head_commit.message, 'Skip Helm E2E Tests') || (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) }}
-    strategy:
-      matrix:
-        k8sVersion: [1.16, 1.17, 1.18, 1.19, 1.20, 1.21]
-    steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.DEFAULT_GO_VERSION }}
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Helm Chart Tests
-        run: test/helm/chart-test.sh -i -k ${{ matrix.k8sVersion }}

--- a/test/helm/chart-test.sh
+++ b/test/helm/chart-test.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # KIND / Kubernetes
 # shellcheck disable=SC2034
-readonly K8s_1_21="v1.21.0"
+readonly K8s_1_21="v1.21.1"
 # shellcheck disable=SC2034
 readonly K8s_1_20="v1.20.0"
 # shellcheck disable=SC2034


### PR DESCRIPTION
Issue #, if available:
* Helm Chart tests failed during the[ last release](https://github.com/aws/amazon-ec2-metadata-mock/actions/runs/1172364115) for 2 reasons:
  * Version 1.20 came to the script as 1.2 and was seen as invalid because the generated var `K8s_1_2` does not exist
  * Version 1.21 is invalid

Description of changes:
* Pass in k8s version matrix as array of strings so the `0` does not get truncated
* Update to valid version 1.21.1
* No longer run on a release:
  * Move into its own GHA workflow file
  * Runs every weekday morning at 5AM CDT
  * This will test releases the very next morning

Testing:
![image](https://user-images.githubusercontent.com/61433408/131404299-189d1cd5-219d-4644-8fc0-341b6ba50afb.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
