### PR TITLE
update mock-ip-count test to use images from gcr

### DIFF
--- a/.github/workflows/helm-chart-test.yaml
+++ b/.github/workflows/helm-chart-test.yaml
@@ -1,8 +1,8 @@
 name: Helm Chart Tests
 
 on:
+  # Run M-F at 5AM CDT
   schedule:
-    - # Run M-F at 5AM CDT
     - cron: '0 10 * * 1-5'
 
 jobs:

--- a/test/helm/chart-test.sh
+++ b/test/helm/chart-test.sh
@@ -116,16 +116,6 @@ setup_ct_container() {
     echo
 }
 
-setup_test_container() {
-    c_echo "Building test container..."
-    TEST_IMAGE_NAME="al2-test:latest"
-    docker build -t $TEST_IMAGE_NAME - <<EOF
-FROM public.ecr.aws/amazonlinux/amazonlinux:latest
-RUN yum update -y && yum install tar -y
-EOF
-    kind load docker-image --name $CLUSTER_NAME --nodes=$CLUSTER_NAME-worker,$CLUSTER_NAME-control-plane $TEST_IMAGE_NAME
-}
-
 install_kind() {
     c_echo "Installing kind..."
     curl -Lo ./kind https://kind.sigs.k8s.io/dl/$KIND_VERSION/kind-$PLATFORM-amd64
@@ -279,7 +269,6 @@ install_and_test_charts() {
         mkdir -p $TMP_DIR
         install_kind
         create_kind_cluster
-        setup_test_container
     fi
 
     c_echo "Installing helm charts and running tests for each *-values.yaml configuration in helm/<chart>/ci dir...\n"
@@ -380,7 +369,6 @@ test_mock_ip_count() {
         mkdir -p $TMP_DIR
         install_kind
         create_kind_cluster
-        setup_test_container
     fi
 
     build_and_load_image

--- a/test/helm/mock-ip-count-test/test-pod-404.yaml
+++ b/test/helm/mock-ip-count-test/test-pod-404.yaml
@@ -7,7 +7,7 @@ spec:
   containers:
   - name: mock-ip-test
     imagePullPolicy: "IfNotPresent"
-    image: "al2-test:latest"
+    image: "mirror.gcr.io/library/centos:latest"
     command:
     - "bash"
     - "-c"

--- a/test/helm/mock-ip-count-test/test-pod.yaml
+++ b/test/helm/mock-ip-count-test/test-pod.yaml
@@ -7,7 +7,7 @@ spec:
   containers:
   - name: mock-ip-test
     imagePullPolicy: "IfNotPresent"
-    image: "al2-test:latest"
+    image: "mirror.gcr.io/library/centos:latest"
     command:
     - "bash"
     - "-c"


### PR DESCRIPTION
Issue #, if available:
* This morning we were throttled by AWS ECR when running Build and Test jobs
  * https://github.com/aws/amazon-ec2-metadata-mock/runs/3460517593?check_suite_focus=true

Description of changes:
* Use gcr for container repo because we are less likely to be throttled

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
