### PR TITLE
cache modules between os and arch build variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Build the manager binary
+# Download the go modules
 FROM golang:1.17 as mod
 
 ## GOLANG env
@@ -13,7 +13,7 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-# Build the manager binary
+# Build binary image
 FROM golang:1.17 as builder
 
 ## GOLANG env
@@ -23,7 +23,7 @@ ARG GOARCH=amd64
 ARG GOPATH=/go
 ARG GOCACHE=/go
 
-# Copy go.mod and download dependencies
+# Copy the dependencies
 WORKDIR /amazon-ec2-metadata-mock
 COPY --from=mod $GOCACHE $GOCACHE
 COPY --from=mod $GOPATH/pkg/mod $GOPATH/pkg/mod
@@ -35,6 +35,7 @@ RUN make build
 # $ docker build  --target=builder -t test .
 ENTRYPOINT ["/amazon-ec2-metadata-mock/build/ec2-metadata-mock"]
 
+# Build the final image with only the binary
 FROM scratch
 WORKDIR /
 COPY --from=builder /amazon-ec2-metadata-mock/build/ec2-metadata-mock .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-# Download the go modules
-FROM golang:1.17 as mod
+FROM golang:1.17 as builder
 
 ## GOLANG env
 ARG GOPROXY="direct"
 ARG GO111MODULE="on"
-ARG GOPATH=/go
-ARG GOCACHE=/go
 
 # Copy go.mod and download dependencies
 WORKDIR /amazon-ec2-metadata-mock
@@ -13,20 +10,10 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-# Build binary image
-FROM golang:1.17 as builder
-
 ## GOLANG env
 ARG CGO_ENABLED=0
 ARG GOOS=linux
 ARG GOARCH=amd64
-ARG GOPATH=/go
-ARG GOCACHE=/go
-
-# Copy the dependencies
-WORKDIR /amazon-ec2-metadata-mock
-COPY --from=mod $GOCACHE $GOCACHE
-COPY --from=mod $GOPATH/pkg/mod $GOPATH/pkg/mod
 
 # Build
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.17 as mod
 
 ## GOLANG env
 ARG GOPROXY="direct"
 ARG GO111MODULE="on"
-ARG CGO_ENABLED=0
-ARG GOOS=linux
-ARG GOARCH=amd64
+ARG GOPATH=/go
+ARG GOCACHE=/go
 
 # Copy go.mod and download dependencies
 WORKDIR /amazon-ec2-metadata-mock
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
+
+# Build the manager binary
+FROM golang:1.17 as builder
+
+## GOLANG env
+ARG CGO_ENABLED=0
+ARG GOOS=linux
+ARG GOARCH=amd64
+ARG GOPATH=/go
+ARG GOCACHE=/go
+
+# Copy go.mod and download dependencies
+WORKDIR /amazon-ec2-metadata-mock
+COPY --from=mod $GOCACHE $GOCACHE
+COPY --from=mod $GOPATH/pkg/mod $GOPATH/pkg/mod
 
 # Build
 COPY . .


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Reduce build times by leveraging docker caching layers. Previously, go mod downloads were not cached between os/arch variants because the build args changed which resulted in docker invalidating the go mod download layer.  
 - Now, we separate out the go mod download into a separate docker build stage and copy the assets since they are os/arch independent which results in the layer being cached. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
