### PR TITLE
Update GOPROXY with google go proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.17 as builder
 
 ## GOLANG env
-ARG GOPROXY="direct"
+ARG GOPROXY="https://proxy.golang.org|direct"
 ARG GO111MODULE="on"
 
 # Copy go.mod and download dependencies

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -4,7 +4,7 @@ ARG WINDOWS_VERSION=1809
 FROM golang:1.17 as builder
 
 # GOLANG env
-ARG GOPROXY="direct"
+ARG GOPROXY="https://proxy.golang.org|direct"
 ARG GO111MODULE="on"
 ARG CGO_ENABLED=0
 ARG GOOS=windows


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
* Updates `GOPROXY` values in Dockerfile to favor google go proxy link. This should improve build times and transient failures during GitHub Actions builds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
