### PR TITLE
Peg versions in Dockerfiles

### DIFF
--- a/test/license-test/Dockerfile
+++ b/test/license-test/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1
+FROM golang:1.17
 
 WORKDIR /app
 
 COPY license-config.hcl .
 ARG GOPROXY="https://proxy.golang.org,direct"
-RUN GO111MODULE=on go get github.com/mitchellh/golicense
+RUN GO111MODULE=on go install github.com/mitchellh/golicense@v0.2.0
 
 CMD $GOPATH/bin/golicense

--- a/test/readme-test/spellcheck-Dockerfile
+++ b/test/readme-test/spellcheck-Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1
+FROM golang:1.17
 
-RUN go get -u github.com/client9/misspell/cmd/misspell
+RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4
 
 CMD [ "/go/bin/misspell" ]


### PR DESCRIPTION
**Issue #, if available:** N/A. The latest ci/cd run failed: https://github.com/aws/amazon-ec2-metadata-mock/actions/runs/1997882752

**Description of changes:**
* aligns golang version with app
* follow best practices for installing a command using `go install`

As of **Go1.18**
```
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
