### PR TITLE
Base64 Userdata

### DIFF
--- a/pkg/config/defaults/aemm-metadata-default-values.json
+++ b/pkg/config/defaults/aemm-metadata-default-values.json
@@ -181,7 +181,7 @@
       "userdata": "/latest/user-data"
     },
     "values": {
-      "userdata": "1234,john,reboot,true|4512,richard,|173,,,"
+      "userdata": "MTIzNCxqb2huLHJlYm9vdCx0cnVlCg=="
     }
   }
 }

--- a/pkg/mock/userdata/userdata.go
+++ b/pkg/mock/userdata/userdata.go
@@ -14,6 +14,8 @@
 package userdata
 
 import (
+	"encoding/base64"
+	"fmt"
 	"log"
 	"net/http"
 	"reflect"
@@ -59,6 +61,13 @@ func RegisterHandlers(config cfg.Config) {
 			value := udValueFieldName.Interface()
 			if path != "" && value != nil {
 				// Ex: "/latest/meta-data/instance-id" : "i-1234567890abcdef0"
+				bvalue, err := base64.StdEncoding.DecodeString(config.Userdata.Values.Userdata)
+				value = string(bvalue)
+
+				if err != nil {
+					fmt.Println("There was an issue decoding base64 data from config")
+					panic(err)
+				}
 				supportedPaths[path] = value
 				if config.Imdsv2Required {
 					server.HandleFunc(path, imdsv2.ValidateToken(Handler))

--- a/pkg/server/httpserver.go
+++ b/pkg/server/httpserver.go
@@ -14,7 +14,6 @@
 package server
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -124,12 +123,6 @@ func FormatAndReturnTextResponse(res http.ResponseWriter, data string) {
 // FormatAndReturnOctetResponse formats the given data into an octet stream and returns the response
 func FormatAndReturnOctetResponse(res http.ResponseWriter, data string) {
 	res.Header().Set("Content-Type", "application/octet-stream")
-	b64d, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		data = ""
-	} else {
-		data = string(b64d)
-	}
 	res.Write([]byte(data))
 	log.Println("Returned octet stream response successfully.")
 	return

--- a/pkg/server/httpserver.go
+++ b/pkg/server/httpserver.go
@@ -14,6 +14,7 @@
 package server
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -123,6 +124,12 @@ func FormatAndReturnTextResponse(res http.ResponseWriter, data string) {
 // FormatAndReturnOctetResponse formats the given data into an octet stream and returns the response
 func FormatAndReturnOctetResponse(res http.ResponseWriter, data string) {
 	res.Header().Set("Content-Type", "application/octet-stream")
+	b64d, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		data = ""
+	} else {
+		data = string(b64d)
+	}
 	res.Write([]byte(data))
 	log.Println("Returned octet stream response successfully.")
 	return

--- a/test/e2e/cmd/userdata-test
+++ b/test/e2e/cmd/userdata-test
@@ -4,7 +4,7 @@ set -euo pipefail
 
 TEST_CONFIG_FILE="$SCRIPTPATH/testdata/aemm-config-integ.json"
 
-USERDATA_DEFAULT="1234,john,reboot,true|4512,richard,|173,,,"
+USERDATA_DEFAULT="1234,john,reboot,true"
 USERDATA_OVERRIDDEN="1234"
 
 ROOT_PATH="http://$HOSTNAME:$AEMM_PORT"

--- a/test/e2e/cmd/userdata-test
+++ b/test/e2e/cmd/userdata-test
@@ -5,7 +5,7 @@ set -euo pipefail
 TEST_CONFIG_FILE="$SCRIPTPATH/testdata/aemm-config-integ.json"
 
 USERDATA_DEFAULT="1234,john,reboot,true"
-USERDATA_OVERRIDDEN="1234"
+USERDATA_OVERRIDDEN="1234,john,reboot,true"
 
 ROOT_PATH="http://$HOSTNAME:$AEMM_PORT"
 USERDATA_TEST_PATH="$ROOT_PATH/latest/user-data"

--- a/test/e2e/testdata/aemm-config-integ.json
+++ b/test/e2e/testdata/aemm-config-integ.json
@@ -37,7 +37,7 @@
       "userdata": "/latest/user-data"
     },
     "values": {
-      "userdata": "MTIzNAo="
+      "userdata": "MTIzNCxqb2huLHJlYm9vdCx0cnVlCg=="
     }
   }
 }

--- a/test/e2e/testdata/aemm-config-integ.json
+++ b/test/e2e/testdata/aemm-config-integ.json
@@ -37,7 +37,7 @@
       "userdata": "/latest/user-data"
     },
     "values": {
-      "userdata": "1234"
+      "userdata": "MTIzNAo="
     }
   }
 }

--- a/test/e2e/testdata/output/aemm-config-used.json
+++ b/test/e2e/testdata/output/aemm-config-used.json
@@ -175,7 +175,7 @@
       "security-groups": "ura-launch-wizard-harry-1",
       "services-domain": "amazonaws.com",
       "services-partition": "aws",
-      "userdata": "1234,john,reboot,true|4512,richard,|173,,,"
+      "userdata": "MTIzNCxqb2huLHJlYm9vdCx0cnVlCg=="
     }
   },
   "mock-delay-sec": 0,


### PR DESCRIPTION
Issue #175

Description of changes:
This allows for userdata to be stored as base64 in the JSON.  This allows for lots of things including multi-line, without needing to put in \n.  Tests should be passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
