### PR TITLE
update marketplaceProductCodes to be list of strings

### DIFF
--- a/pkg/mock/dynamic/types/types.go
+++ b/pkg/mock/dynamic/types/types.go
@@ -15,19 +15,19 @@ package types
 
 // InstanceIdentityDocument structure for mock json response parsing
 type InstanceIdentityDocument struct {
-	AccountId               string  `json:"accountId"`
-	ImageId                 string  `json:"imageId"`
-	AvailabilityZone        string  `json:"availabilityZone"`
-	RamdiskId               *string `json:"ramdiskId"`
-	KernelId                *string `json:"kernelId"`
-	DevpayProductCodes      *string `json:"devpayProductCodes"`
-	MarketplaceProductCodes *string `json:"marketplaceProductCodes"`
-	Version                 string  `json:"version"`
-	PrivateIp               string  `json:"privateIp"`
-	BillingProducts         *string `json:"billingProducts"`
-	InstanceId              string  `json:"instanceId"`
-	PendingTime             string  `json:"pendingTime"`
-	Architecture            string  `json:"architecture"`
-	InstanceType            string  `json:"instanceType"`
-	Region                  string  `json:"region"`
+	AccountId               string   `json:"accountId"`
+	ImageId                 string   `json:"imageId"`
+	AvailabilityZone        string   `json:"availabilityZone"`
+	RamdiskId               *string  `json:"ramdiskId"`
+	KernelId                *string  `json:"kernelId"`
+	DevpayProductCodes      *string  `json:"devpayProductCodes"`
+	MarketplaceProductCodes []string `json:"marketplaceProductCodes"`
+	Version                 string   `json:"version"`
+	PrivateIp               string   `json:"privateIp"`
+	BillingProducts         *string  `json:"billingProducts"`
+	InstanceId              string   `json:"instanceId"`
+	PendingTime             string   `json:"pendingTime"`
+	Architecture            string   `json:"architecture"`
+	InstanceType            string   `json:"instanceType"`
+	Region                  string   `json:"region"`
 }

--- a/pkg/server/httpserver_test.go
+++ b/pkg/server/httpserver_test.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/dynamic/types"
+	h "github.com/aws/amazon-ec2-metadata-mock/test"
+)
+
+func TestFormatAndReturnJSONResponse(t *testing.T) {
+	expected := `{
+	"accountId": "123456789012",
+	"imageId": "ami-02f471c4f805553d3",
+	"availabilityZone": "us-east-1a",
+	"ramdiskId": null,
+	"kernelId": null,
+	"devpayProductCodes": null,
+	"marketplaceProductCodes": ["4i20ezfza3p7xx2kt2g8weu2u","entry"],
+	"version": "2017-09-30",
+	"privateIp": "172.31.85.190",
+	"billingProducts": null,
+	"instanceId": "i-048bcb15d2686eec7",
+	"pendingTime": "2022-06-23T06:21:55Z",
+	"architecture": "x86_64",
+	"instanceType": "t2.nano",
+	"region": "us-east-1"
+}`
+
+	testDoc := types.InstanceIdentityDocument{
+		AccountId:               "123456789012",
+		ImageId:                 "ami-02f471c4f805553d3",
+		AvailabilityZone:        "us-east-1a",
+		RamdiskId:               nil,
+		KernelId:                nil,
+		DevpayProductCodes:      nil,
+		MarketplaceProductCodes: []string{"4i20ezfza3p7xx2kt2g8weu2u", "entry"},
+		Version:                 "2017-09-30",
+		PrivateIp:               "172.31.85.190",
+		BillingProducts:         nil,
+		InstanceId:              "i-048bcb15d2686eec7",
+		PendingTime:             "2022-06-23T06:21:55Z",
+		Architecture:            "x86_64",
+		InstanceType:            "t2.nano",
+		Region:                  "us-east-1",
+	}
+	rr := httptest.NewRecorder()
+	FormatAndReturnJSONResponse(rr, testDoc)
+	actual := rr.Body.String()
+	h.Assert(t, expected == actual, "FormatAndReturnJSONResponse did not format InstanceIdentityDocument as expected.")
+}

--- a/test/e2e/cmd/dynamic-test
+++ b/test/e2e/cmd/dynamic-test
@@ -45,6 +45,7 @@ function test_dynamic_idc_overrides() {
   pid=$1
   expected_account_id=$2
   expected_instance_id=$3
+  expected_mp_codes=[\""4i20ezfza3p7xx2kt2g8weu2u\""]
   tput setaf $YELLOW
   health_check $DYNAMIC_TEST_PATH
   TOKEN=$(get_v2Token $MAX_TOKEN_TTL $AEMM_PORT)
@@ -52,9 +53,12 @@ function test_dynamic_idc_overrides() {
   response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $DYNAMIC_IDC_TEST_PATH)
   actual_account_id=$(get_value '"accountId"' "$response")
   actual_instance_id=$(get_value '"instanceId"' "$response")
+  # use '--compact-output' to return the value on a single line (i.e. do not pretty print)  
+  actual_marketplace_codes=$(echo "$response" | jq -c '.marketplaceProductCodes')
 
   assert_value "$actual_account_id" $expected_account_id 'Override dynamic_idc::accountId'
   assert_value "$actual_instance_id" $expected_instance_id 'Override dynamic_idc::instanceId'
+  assert_value "$actual_marketplace_codes" "$expected_mp_codes" 'Override dynamic_idc::marketplaceProductCodes'
 
   clean_up $pid
 }

--- a/test/e2e/testdata/aemm-config-integ.json
+++ b/test/e2e/testdata/aemm-config-integ.json
@@ -21,7 +21,7 @@
         "ramdiskId": null,
         "kernelId": null,
         "devpayProductCodes": null,
-        "marketplaceProductCodes": null,
+        "marketplaceProductCodes": ["4i20ezfza3p7xx2kt2g8weu2u"],
         "version": "2017-09-30",
         "privateIp": "10.0.7.10",
         "billingProducts": null,


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/amazon-ec2-metadata-mock/issues/179

Description of changes:
* change `marketplaceProductCodes` from `string` to `[]string` and formatting logic to align with IMDS 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
