### PR TITLE
Update helm-chart-test to run in the afternoon

### DIFF
--- a/.github/workflows/helm-chart-test.yaml
+++ b/.github/workflows/helm-chart-test.yaml
@@ -1,9 +1,9 @@
 name: Helm Chart Tests
 
 on:
-  # Run M-F at 5AM CDT
+  # Run M-F at 2pm CDT
   schedule:
-    - cron: '0 10 * * 1-5'
+    - cron: '0 19 * * 1-5'
 
 jobs:
   chartTests:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

We [recently changed](https://github.com/aws/amazon-ec2-metadata-mock/pull/181) the `build-and-test` run to 2 PM Central time, and we've seen fewer transient failures since that change. This PR updates the `helm-chart-test` run to the same time in the afternoon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
