### PR TITLE
update test regex for base64

### DIFF
--- a/pkg/mock/imdsv2/imdsv2_test.go
+++ b/pkg/mock/imdsv2/imdsv2_test.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	testURL             = "http://test-example.com/"
-	tokenRegex          = "^[a-zA-Z0-9]{43}="
+	tokenRegex          = "^[a-zA-Z0-9+/]{43}="
 	successMockResponse = "Success!"
 )
 


### PR DESCRIPTION
Issue #, if available:

Sporadic test suite failures with errors like

```
imdsv2_test.go:47: Expected valid token generation, but was qAnm5A4tWlsq+hk0Ze0Qb/XT8dLb/aXJftHPJorwJnE=
```

Description of changes:

Update regex used by the test to include all valid base64 characters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
