### PR TITLE
added support for asg target-lifecycle-state path

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,8 +409,10 @@ The `asglifecycle` command will generate a asg lifecycle termination event after
 ```
 $ ec2-metadata-mock asglifecycle --help
 Mock EC2 Auto Scaling Group Lifecycle Termination State
+
 Usage:
   ec2-metadata-mock asglifecycle
+
 Aliases:
   asglifecycle, autoscaling, asg
 ```

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Available Commands:
   asglifecycle  Mock ASG target-lifecycle-state changes from InService to Terminated
 
 Flags:
-  -g, --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
+      --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
       --asg-termination-trigger-time int   asg termination trigger time in RFC3339 format. This takes priority over asg-termination-delay-sec (default: none)
   -c, --config-file string                 config file for cli input parameters in json format (default: $HOME/aemm-config.json)
   -h, --help                               help for ec2-metadata-mock
@@ -255,8 +255,8 @@ Flags:
   -t, --time string                    termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
-  -g, --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
-    --asg-termination-trigger-time int   asg termination trigger time in RFC3339 format. This takes priority over asg-termination-delay-sec (default: none)
+      --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
+      --asg-termination-trigger-time int   asg termination trigger time in RFC3339 format. This takes priority over asg-termination-delay-sec (default: none)
   -c, --config-file string                 config file for cli input parameters in json format (default: $HOME/aemm-config.json)
   -h, --help                               help for ec2-metadata-mock
   -n, --hostname string                    the HTTP hostname for the mock url (default: 0.0.0.0)
@@ -404,36 +404,15 @@ $ curl localhost:1338/latest/meta-data/events/maintenance/scheduled
 ```
 
 ## Auto Scaling Group Lifecycle Termination
-Similar to spot, the `asglifecycle` command, view the local flags using `asglifecycle --help`:
+The `asglifecycle` command will generate a asg lifecycle termination event after a user-specified delay or termination time. 
 
 ```
 $ ec2-metadata-mock asglifecycle --help
 Mock EC2 Auto Scaling Group Lifecycle Termination State
-
 Usage:
   ec2-metadata-mock asglifecycle
-
 Aliases:
   asglifecycle, autoscaling, asg
-
-Examples:
-  ec2-metadata-mock asglifecycle -h   asglifecycle help
-
-Global Flags:
-  -g, --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
-      --asg-termination-trigger-time int   asg termination trigger time in RFC3339 format. This takes priority over asg-termination-delay-sec (default: none)
-  -c, --config-file string                 config file for cli input parameters in json format (default: $HOME/aemm-config.json)
-  -h, --help                               help for ec2-metadata-mock
-  -n, --hostname string                    the HTTP hostname for the mock url (default: 0.0.0.0)
-  -I, --imdsv2                             whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
-  -d, --mock-delay-sec int                 spot itn delay in seconds, relative to the application start time (default: 0 seconds)
-  -x, --mock-ip-count int                  number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
-      --mock-trigger-time string           spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
-  -p, --port string                        the HTTP port where the mock runs (default: 1338)
-      --rebalance-delay-sec int            rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
-      --rebalance-trigger-time string      rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
-  -s, --save-config-to-file                whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
-  -v, --version                            version for ec2-metadata-mock
 ```
 
 Send the request:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
    * [Usage](#usage)
       * [Spot Interruption](#spot-interruption)
       * [Scheduled Events](#events)
+      * [Auto Scaling Group Lifecycle Termination](#Auto-Scaling-Group-Lifecycle-Termination)
       * [Instance Metadata Service Versions](#instance-metadata-service-versions)
       * [Static Metadata](#static-metadata)
    * [Troubleshooting](#troubleshooting)
@@ -46,7 +47,7 @@
    * [License](#license)
 
 # Summary
-AWS EC2 Instance metadata is data about your instance that you can use to configure or manage the running instance. Instance metadata is divided into categories like hostname, instance id, maintenance events, spot instance action. See the complete list of metadata categories [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html).
+AWS EC2 Instance metadata is data about your instance that you can use to configure or manage the running instance. Instance metadata is divided into categories like hostname, instance id, maintenance events, spot instance action, autoscaling target-lifecycle-state. See the complete list of metadata categories [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html).
 
 The instance metadata can be accessed from within the instance. Some instance metadata is available only when an instance is affected by the event. E.g. A Spot instance's metadata item `spot/instance-action` is available only when AWS decides to interrupt the Spot instance.
 These bring forth some challenges like not being able to test one's application in the event of Spot interruption or other such events and requiring an EC2 instance for testing.
@@ -138,23 +139,26 @@ Examples:
   ec2-metadata-mock spot --action terminate	mocks spot ITN only
 
 Available Commands:
-  events      Mock EC2 maintenance events
-  help        Help about any command
-  spot        Mock EC2 Spot interruption notice
+  events        Mock EC2 maintenance events
+  help          Help about any command
+  spot          Mock EC2 Spot interruption notice
+  asglifecycle  Mock ASG target-lifecycle-state changes from InService to Terminated
 
 Flags:
-  -c, --config-file string              config file for cli input parameters in json format (default: $HOME/aemm-config.json)
-  -h, --help                            help for ec2-metadata-mock
-  -n, --hostname string                 the HTTP hostname for the mock url (default: 0.0.0.0)
-  -I, --imdsv2                          whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
-  -d, --mock-delay-sec int              spot itn delay in seconds, relative to the application start time (default: 0 seconds)
-  -x, --mock-ip-count int               number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
-      --mock-trigger-time string        spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
-  -p, --port string                     the HTTP port where the mock runs (default: 1338)
-      --rebalance-delay-sec int         rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
-      --rebalance-trigger-time string   rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
-  -s, --save-config-to-file             whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
-      --version                         version for ec2-metadata-mock
+  -g, --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
+      --asg-termination-trigger-time int   asg termination trigger time in RFC3339 format. This takes priority over asg-termination-delay-sec (default: none)
+  -c, --config-file string                 config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -h, --help                               help for ec2-metadata-mock
+  -n, --hostname string                    the HTTP hostname for the mock url (default: 0.0.0.0)
+  -I, --imdsv2                             whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int                 spot itn delay in seconds, relative to the application start time (default: 0 seconds)
+  -x, --mock-ip-count int                  number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
+      --mock-trigger-time string           spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
+  -p, --port string                        the HTTP port where the mock runs (default: 1338)
+      --rebalance-delay-sec int            rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
+      --rebalance-trigger-time string      rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
+  -s, --save-config-to-file                whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+  -v, --version                            version for ec2-metadata-mock
 
 Use "ec2-metadata-mock [command] --help" for more information about a command.
 ```
@@ -177,6 +181,7 @@ $ curl localhost:1338/latest/meta-data
 ami-id
 ami-launch-index
 ami-manifest-path
+autoscaling/
 block-device-mapping/
 elastic-inference/
 events/
@@ -250,16 +255,20 @@ Flags:
   -t, --time string                    termination time specifies the approximate time when the spot instance will receive the shutdown signal in RFC3339 format to execute instance action E.g. 2020-01-07T01:03:47Z (default: request time + 2 minutes in UTC)
 
 Global Flags:
-  -c, --config-file string              config file for cli input parameters in json format (default: $HOME/aemm-config.json)
-  -n, --hostname string                 the HTTP hostname for the mock url (default: 0.0.0.0)
-  -I, --imdsv2                          whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
-  -d, --mock-delay-sec int              spot itn delay in seconds, relative to the application start time (default: 0 seconds)
-  -x, --mock-ip-count int               number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
-      --mock-trigger-time string        spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
-  -p, --port string                     the HTTP port where the mock runs (default: 1338)
-      --rebalance-delay-sec int         rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
-      --rebalance-trigger-time string   rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
-  -s, --save-config-to-file             whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+  -g, --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
+    --asg-termination-trigger-time int   asg termination trigger time in RFC3339 format. This takes priority over asg-termination-delay-sec (default: none)
+  -c, --config-file string                 config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -h, --help                               help for ec2-metadata-mock
+  -n, --hostname string                    the HTTP hostname for the mock url (default: 0.0.0.0)
+  -I, --imdsv2                             whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int                 spot itn delay in seconds, relative to the application start time (default: 0 seconds)
+  -x, --mock-ip-count int                  number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
+      --mock-trigger-time string           spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
+  -p, --port string                        the HTTP port where the mock runs (default: 1338)
+      --rebalance-delay-sec int            rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
+      --rebalance-trigger-time string      rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
+  -s, --save-config-to-file                whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+  -v, --version                            version for ec2-metadata-mock
 ```
 
 1.) **Starting AEMM with `spot`**:  `spot` routes available immediately:
@@ -392,6 +401,45 @@ $ curl localhost:1338/latest/meta-data/events/maintenance/scheduled
 	"NotAfter": "7 Jan 2020 01:03:47 GMT",
 	"NotBeforeDeadline": "10 Jan 2020 01:03:47 GMT"
 }
+```
+
+## Auto Scaling Group Lifecycle Termination
+Similar to spot, the `asglifecycle` command, view the local flags using `asglifecycle --help`:
+
+```
+$ ec2-metadata-mock asglifecycle --help
+Mock EC2 Auto Scaling Group Lifecycle Termination State
+
+Usage:
+  ec2-metadata-mock asglifecycle
+
+Aliases:
+  asglifecycle, autoscaling, asg
+
+Examples:
+  ec2-metadata-mock asglifecycle -h   asglifecycle help
+
+Global Flags:
+  -g, --asg-termination-delay-sec int      asg termination delay in seconds, relative to the application start time (default: 0 seconds)
+      --asg-termination-trigger-time int   asg termination trigger time in RFC3339 format. This takes priority over asg-termination-delay-sec (default: none)
+  -c, --config-file string                 config file for cli input parameters in json format (default: $HOME/aemm-config.json)
+  -h, --help                               help for ec2-metadata-mock
+  -n, --hostname string                    the HTTP hostname for the mock url (default: 0.0.0.0)
+  -I, --imdsv2                             whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)
+  -d, --mock-delay-sec int                 spot itn delay in seconds, relative to the application start time (default: 0 seconds)
+  -x, --mock-ip-count int                  number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event (default 2)
+      --mock-trigger-time string           spot itn trigger time in RFC3339 format. This takes priority over mock-delay-sec (default: none)
+  -p, --port string                        the HTTP port where the mock runs (default: 1338)
+      --rebalance-delay-sec int            rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)
+      --rebalance-trigger-time string      rebalance rec trigger time in RFC3339 format. This takes priority over rebalance-delay-sec (default: none)
+  -s, --save-config-to-file                whether to save processed config from all input sources in .ec2-metadata-mock/.aemm-config-used.json in $HOME or working dir, if homedir is not found (default: false)
+  -v, --version                            version for ec2-metadata-mock
+```
+
+Send the request:
+```
+$ curl localhost:1338/latest/meta-data/autoscaling/target-lifecycle-state
+Terminated
 ```
 
 ## Instance Metadata Service Versions

--- a/pkg/cmd/asglifecycle/asglifecycle.go
+++ b/pkg/cmd/asglifecycle/asglifecycle.go
@@ -1,0 +1,92 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package asglifecycle
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	cmdutil "github.com/aws/amazon-ec2-metadata-mock/pkg/cmd/cmdutil"
+	cfg "github.com/aws/amazon-ec2-metadata-mock/pkg/config"
+	se "github.com/aws/amazon-ec2-metadata-mock/pkg/mock/asglifecycle"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	cfgPrefix = "asglifecycle."
+)
+
+var (
+	c cfg.Config
+
+	// Command represents the CLI command
+	Command *cobra.Command
+
+	// defaults
+	defaultCfg = map[string]interface{}{}
+)
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	Command = newCmd()
+}
+
+func initConfig() {
+	cfg.LoadConfigFromDefaults(defaultCfg)
+}
+
+func newCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "asglifecycle [--code CODE] [--state STATE] [--not-after] [--not-before-deadline]",
+		Aliases: []string{"asglifecycle", "autoscaling", "asg"},
+		PreRunE: preRun,
+		Example: fmt.Sprintf("  %s asglifecycle -h \tasglifecycle help \n  %s asglifecycle -t target-lifecycle-state\t\tmocks asg lifecycle target lifecycle states", cmdutil.BinName, cmdutil.BinName),
+		Run:     run,
+		Short:   "Mock EC2 ASG Lifecycle target-lifecycle-state",
+		Long:    "Mock EC2 ASG Lifecycle target-lifecycle-state",
+	}
+
+	// bind local flags to config
+	cfg.BindFlagSetWithKeyPrefix(cmd.Flags(), cfgPrefix)
+	return cmd
+}
+
+// SetConfig sets the local config
+func SetConfig(config cfg.Config) {
+	c = config
+}
+
+func preRun(cmd *cobra.Command, args []string) error {
+	if cfgErrors := ValidateLocalConfig(); cfgErrors != nil {
+		return errors.New(strings.Join(cfgErrors, ""))
+	}
+	return nil
+}
+
+// ValidateLocalConfig validates all local config and returns a slice of error messages
+func ValidateLocalConfig() []string {
+	var errStrings []string
+
+	return errStrings
+}
+
+func run(cmd *cobra.Command, args []string) {
+	log.Printf("Initiating %s for EC2 ASG Lifecycle on port %s\n", cmdutil.BinName, c.Server.Port)
+	cmdutil.PrintFlags(cmd.Flags())
+	cmdutil.RegisterHandlers(cmd, c)
+	se.Mock(c)
+}

--- a/pkg/cmd/asglifecycle/asglifecycle.go
+++ b/pkg/cmd/asglifecycle/asglifecycle.go
@@ -79,9 +79,8 @@ func preRun(cmd *cobra.Command, args []string) error {
 
 // ValidateLocalConfig validates all local config and returns a slice of error messages
 func ValidateLocalConfig() []string {
-	var errStrings []string
-
-	return errStrings
+	// no-op
+	return nil
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/asglifecycle/asglifecycle_test.go
+++ b/pkg/cmd/asglifecycle/asglifecycle_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package asglifecycle
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	h "github.com/aws/amazon-ec2-metadata-mock/test"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewCmdName(t *testing.T) {
+	expected := "asglifecycle"
+	actual := newCmd().Name()
+	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for asglifecycle command to be %s, but was %s", expected, actual))
+}
+func TestNewCmdLocalFlags(t *testing.T) {
+	expectedFlags := []string{}
+
+	cmd := newCmd()
+	actualFlagSet := cmd.LocalFlags()
+
+	var actualFlags []string
+	actualFlagSet.VisitAll(func(flag *pflag.Flag) {
+		actualFlags = append(actualFlags, flag.Name)
+	})
+
+	h.ItemsMatch(t, expectedFlags, actualFlags)
+}
+
+func TestNewCmdHasPreRunE(t *testing.T) {
+	pre := newCmd().PreRunE
+	h.Assert(t, pre != nil, "Expected a non nil PreRunE for the asglifecycle command")
+}
+
+func TestNewCmdHasRun(t *testing.T) {
+	run := newCmd().Run
+	h.Assert(t, run != nil, "Expected a non nil Run for the asglifecycle command")
+}
+func TestNewCmdHasExample(t *testing.T) {
+	hasExample := newCmd().HasExample()
+	h.Assert(t, hasExample, "Expected asglifecycle command to have an example, but wasn't found")
+}
+func TestExecuteHelpExists(t *testing.T) {
+	cmd := newCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOutput(buf)
+	cmd.SetArgs([]string{"-h"})
+	err := cmd.Execute()
+	h.Ok(t, err)
+
+	output := buf.String()
+	h.Assert(t, output != "", "Expected help subcommand for asglifecycle, but wasn't found")
+}

--- a/pkg/cmd/cmdutil/cmdutil.go
+++ b/pkg/cmd/cmdutil/cmdutil.go
@@ -20,6 +20,7 @@ import (
 
 	cfg "github.com/aws/amazon-ec2-metadata-mock/pkg/config"
 	e "github.com/aws/amazon-ec2-metadata-mock/pkg/error"
+	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/asglifecycle"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/dynamic"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/events"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/handlers"
@@ -110,18 +111,22 @@ func getHandlerPairs(cmd *cobra.Command, config cfg.Config) []handlerPair {
 
 	isSpot := strings.Contains(cmd.Name(), "spot")
 	isEvents := strings.Contains(cmd.Name(), "events")
+	isASGLifecycle := strings.Contains(cmd.Name(), "asglifecycle")
 
 	subCommandHandlers := map[string][]handlerPair{
 		"spot": {{path: config.Metadata.Paths.Spot, handler: spot.Handler},
 			{path: config.Metadata.Paths.SpotTerminationTime, handler: spot.Handler},
 			{path: config.Metadata.Paths.RebalanceRecTime, handler: spot.Handler}},
-		"events": {{path: config.Metadata.Paths.Events, handler: events.Handler}},
+		"events":       {{path: config.Metadata.Paths.Events, handler: events.Handler}},
+		"asglifecycle": {{path: config.Metadata.Paths.ASGLifecycle, handler: asglifecycle.Handler}},
 	}
 
 	if isSpot {
 		handlerPairs = append(handlerPairs, subCommandHandlers["spot"]...)
 	} else if isEvents {
 		handlerPairs = append(handlerPairs, subCommandHandlers["events"]...)
+	} else if isASGLifecycle {
+		handlerPairs = append(handlerPairs, subCommandHandlers["asglifecycle"]...)
 	} else {
 		// root registers all subcommands
 		for k := range subCommandHandlers {

--- a/pkg/cmd/root/globalflags/globalflags.go
+++ b/pkg/cmd/root/globalflags/globalflags.go
@@ -44,9 +44,13 @@ const (
 
 	// RebalanceTriggerTimeFlag - rebalance rec trigger time in RFC3339
 	RebalanceTriggerTimeFlag = "rebalance-trigger-time"
+
+	ASGTerminationDelayInSecFlag = "asg-termination-delay-sec"
+
+	ASGTerminationTriggerTimeFlag = "asg-termination-trigger-time"
 )
 
 // GetTopLevelFlags returns the top level global flags
 func GetTopLevelFlags() []string {
-	return []string{ConfigFileFlag, SaveConfigToFileFlag, MockDelayInSecFlag, MockTriggerTimeFlag, MockIPCountFlag, Imdsv2Flag, RebalanceDelayInSecFlag, RebalanceTriggerTimeFlag}
+	return []string{ConfigFileFlag, SaveConfigToFileFlag, MockDelayInSecFlag, MockTriggerTimeFlag, MockIPCountFlag, Imdsv2Flag, RebalanceDelayInSecFlag, RebalanceTriggerTimeFlag, ASGTerminationDelayInSecFlag, ASGTerminationTriggerTimeFlag}
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -47,7 +47,7 @@ var (
 		gf.ConfigFileFlag:                cfg.GetDefaultCfgFileName(),
 		gf.MockDelayInSecFlag:            0,
 		gf.MockTriggerTimeFlag:           "",
-		gf.MockIPCountFlag:               3,
+		gf.MockIPCountFlag:               2,
 		gf.SaveConfigToFileFlag:          false,
 		gf.Imdsv2Flag:                    false,
 		gf.RebalanceDelayInSecFlag:       0,

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -92,7 +92,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolP(gf.Imdsv2Flag, "I", false, "whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)")
 	cmd.PersistentFlags().Int64(gf.RebalanceDelayInSecFlag, 0, "rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)")
 	cmd.PersistentFlags().String(gf.RebalanceTriggerTimeFlag, "", "rebalance rec trigger time in RFC3339 format. This takes priority over "+gf.RebalanceDelayInSecFlag+" (default: none)")
-	cmd.PersistentFlags().Int64P(gf.ASGTerminationDelayInSecFlag, "g", 0, "asg termination delay in seconds, relative to the application start time (default: 0 seconds)")
+	cmd.PersistentFlags().Int64P(gf.ASGTerminationDelayInSecFlag, "", 0, "asg termination delay in seconds, relative to the application start time (default: 0 seconds)")
 	cmd.PersistentFlags().Int64P(gf.ASGTerminationTriggerTimeFlag, "", 0, "asg termination trigger time in RFC3339 format. This takes priority over "+gf.ASGTerminationDelayInSecFlag+" (default: none)")
 
 	// add subcommands

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/aws/amazon-ec2-metadata-mock/pkg/cmd/asglifecycle"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/cmd/cmdutil"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/cmd/events"
 	gf "github.com/aws/amazon-ec2-metadata-mock/pkg/cmd/root/globalflags"
@@ -43,14 +44,16 @@ var (
 	cfgMdPrefix = cfg.GetCfgMdValPrefix()
 	cfgDnPrefix = cfg.GetCfgDnValPrefix()
 	defaultCfg  = map[string]interface{}{
-		gf.ConfigFileFlag:           cfg.GetDefaultCfgFileName(),
-		gf.MockDelayInSecFlag:       0,
-		gf.MockTriggerTimeFlag:      "",
-		gf.MockIPCountFlag:          2,
-		gf.SaveConfigToFileFlag:     false,
-		gf.Imdsv2Flag:               false,
-		gf.RebalanceDelayInSecFlag:  0,
-		gf.RebalanceTriggerTimeFlag: "",
+		gf.ConfigFileFlag:                cfg.GetDefaultCfgFileName(),
+		gf.MockDelayInSecFlag:            0,
+		gf.MockTriggerTimeFlag:           "",
+		gf.MockIPCountFlag:               3,
+		gf.SaveConfigToFileFlag:          false,
+		gf.Imdsv2Flag:                    false,
+		gf.RebalanceDelayInSecFlag:       0,
+		gf.RebalanceTriggerTimeFlag:      "",
+		gf.ASGTerminationDelayInSecFlag:  0,
+		gf.ASGTerminationTriggerTimeFlag: "",
 	}
 )
 
@@ -89,9 +92,11 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolP(gf.Imdsv2Flag, "I", false, "whether to enable IMDSv2 only, requiring a session token when submitting requests (default: false, meaning both IMDS v1 and v2 are enabled)")
 	cmd.PersistentFlags().Int64(gf.RebalanceDelayInSecFlag, 0, "rebalance rec delay in seconds, relative to the application start time (default: 0 seconds)")
 	cmd.PersistentFlags().String(gf.RebalanceTriggerTimeFlag, "", "rebalance rec trigger time in RFC3339 format. This takes priority over "+gf.RebalanceDelayInSecFlag+" (default: none)")
+	cmd.PersistentFlags().Int64P(gf.ASGTerminationDelayInSecFlag, "g", 0, "asg termination delay in seconds, relative to the application start time (default: 0 seconds)")
+	cmd.PersistentFlags().Int64P(gf.ASGTerminationTriggerTimeFlag, "", 0, "asg termination trigger time in RFC3339 format. This takes priority over "+gf.ASGTerminationDelayInSecFlag+" (default: none)")
 
 	// add subcommands
-	cmd.AddCommand(spot.Command, events.Command)
+	cmd.AddCommand(spot.Command, events.Command, asglifecycle.Command)
 
 	// bind all non-metadata flags at top level
 	var topLevelGFlags []*pflag.Flag
@@ -140,6 +145,7 @@ func setConfig(config cfg.Config) {
 	c = config
 	spot.SetConfig(config)
 	events.SetConfig(config)
+	asglifecycle.SetConfig(config)
 }
 
 func preRun(cmd *cobra.Command, args []string) error {
@@ -155,6 +161,7 @@ func validateConfig() []string {
 	// validate subcommands' config
 	errStrings = append(errStrings, spot.ValidateLocalConfig()...)
 	errStrings = append(errStrings, events.ValidateLocalConfig()...)
+	errStrings = append(errStrings, asglifecycle.ValidateLocalConfig()...)
 
 	if c.MockTriggerTime != "" {
 		if err := cmdutil.ValidateRFC3339TimeFormat(gf.MockTriggerTimeFlag, c.MockTriggerTime); err != nil {

--- a/pkg/cmd/root/root_test.go
+++ b/pkg/cmd/root/root_test.go
@@ -31,7 +31,7 @@ func TestNewCmdName(t *testing.T) {
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for root command to be %s, but was %s", expected, actual))
 }
 func TestNewCmdFlags(t *testing.T) {
-	expectedFlags := []string{"config-file", "save-config-to-file", "mock-delay-sec", "mock-trigger-time", "mock-ip-count", "hostname", "port", "imdsv2", "rebalance-delay-sec", "rebalance-trigger-time"}
+	expectedFlags := []string{"config-file", "save-config-to-file", "mock-delay-sec", "mock-trigger-time", "mock-ip-count", "hostname", "port", "imdsv2", "rebalance-delay-sec", "rebalance-trigger-time", "asg-termination-delay-sec", "asg-termination-trigger-time"}
 
 	cmd := NewCmd()
 	actualFlagSet := cmd.PersistentFlags()
@@ -43,7 +43,7 @@ func TestNewCmdFlags(t *testing.T) {
 	h.ItemsMatch(t, expectedFlags, actualFlags)
 }
 func TestNewCmdHasSubcommands(t *testing.T) {
-	expSubcommandNames := []string{"spot", "events"}
+	expSubcommandNames := []string{"spot", "events", "asglifecycle"}
 
 	cmd := NewCmd()
 	actSubcommands := cmd.Commands()

--- a/pkg/config/defaults/aemm-metadata-default-values.json
+++ b/pkg/config/defaults/aemm-metadata-default-values.json
@@ -63,7 +63,8 @@
       "spot-termination-time": "/latest/meta-data/spot/termination-time",
       "rebalance-rec-time": "/latest/meta-data/events/recommendations/rebalance",
       "tags-instance-name": "/latest/meta-data/tags/instance/Name",
-      "tags-instance-test": "/latest/meta-data/tags/instance/Test"
+      "tags-instance-test": "/latest/meta-data/tags/instance/Test",
+      "target-lifecycle-state": "/latest/meta-data/autoscaling/target-lifecycle-state"
     },
     "values": {
       "ami-id": "ami-0a887e401f7654935",

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -29,15 +29,19 @@ type Config struct {
 
 	// ----- CLI config ----- //
 	// config keys that are also cli flags
-	CfgFile              string `mapstructure:"config-file"`
-	MockDelayInSec       int64  `mapstructure:"mock-delay-sec"`
-	MockTriggerTime      string `mapstructure:"mock-trigger-time"`
-	MockIPCount          int    `mapstructure:"mock-ip-count"`
-	SaveConfigToFile     bool   `mapstructure:"save-config-to-file"`
-	Server               Server `mapstructure:"server"`
-	Imdsv2Required       bool   `mapstructure:"imdsv2"`
-	RebalanceDelayInSec  int64  `mapstructure:"rebalance-delay-sec"`
-	RebalanceTriggerTime string `mapstructure:"rebalance-trigger-time"`
+	CfgFile                   string `mapstructure:"config-file"`
+	MockDelayInSec            int64  `mapstructure:"mock-delay-sec"`
+	MockTriggerTime           string `mapstructure:"mock-trigger-time"`
+	MockIPCount               int    `mapstructure:"mock-ip-count"`
+	SaveConfigToFile          bool   `mapstructure:"save-config-to-file"`
+	Server                    Server `mapstructure:"server"`
+	Imdsv2Required            bool   `mapstructure:"imdsv2"`
+	RebalanceDelayInSec       int64  `mapstructure:"rebalance-delay-sec"`
+	RebalanceTriggerTime      string `mapstructure:"rebalance-trigger-time"`
+	ASGTerminationDelayInSec  int64  `mapstructure:"asg-termination-delay-sec"`
+	ASGTerminationTriggerTime string `mapstructure:"asg-termination-trigger-time"`
+
+	// ----- static config ----- //
 
 	// config keys for subcommands
 	SpotConfig   spot.Config   `mapstructure:"spot"`
@@ -76,6 +80,7 @@ type Paths struct {
 	AmiID                        string `mapstructure:"ami-id"`
 	AmiLaunchIndex               string `mapstructure:"ami-launch-index"`
 	AmiManifestPath              string `mapstructure:"ami-manifest-path"`
+	ASGLifecycle                 string `mapstructure:"target-lifecycle-state"`
 	BlockDeviceMappingAmi        string `mapstructure:"block-device-mapping-ami"`
 	BlockDeviceMappingEbs        string `mapstructure:"block-device-mapping-ebs"`
 	BlockDeviceMappingEphemeral  string `mapstructure:"block-device-mapping-ephemeral"`

--- a/pkg/mock/asglifecycle/asglifecycle.go
+++ b/pkg/mock/asglifecycle/asglifecycle.go
@@ -28,10 +28,10 @@ const (
 )
 
 var (
-	eligibleIPs          = make(map[string]bool)
-	c                    cfg.Config
-	autoscalingStartTime int64 = time.Now().Unix()
-	state                      = "InService"
+	eligibleIPs  = make(map[string]bool)
+	c            cfg.Config
+	asgStartTime int64 = time.Now().Unix()
+	state              = "InService"
 )
 
 func Mock(config cfg.Config) {
@@ -53,7 +53,7 @@ func Handler(res http.ResponseWriter, req *http.Request) {
 			if len(eligibleIPs) < c.MockIPCount {
 				eligibleIPs[requestIP] = true
 			} else {
-				log.Printf("Requesting IP %s is not eligible for Spot ITN or Rebalance Recommendation because the max number of IPs configured (%d) has been reached.\n", requestIP, c.MockIPCount)
+				log.Printf("Requesting IP %s is not eligible for ASG Lifecycle State because the max number of IPs configured (%d) has been reached.\n", requestIP, c.MockIPCount)
 				server.ReturnNotFoundResponse(res)
 				return
 			}
@@ -76,7 +76,7 @@ func handleASGTargetLifecycleState(res http.ResponseWriter, req *http.Request) {
 		}
 	} else {
 		delayInSeconds := c.ASGTerminationDelayInSec
-		delayRemaining := delayInSeconds - (requestTime - autoscalingStartTime)
+		delayRemaining := delayInSeconds - (requestTime - asgStartTime)
 		if delayRemaining <= 0 {
 			state = "Terminated"
 		}

--- a/pkg/mock/asglifecycle/asglifecycle.go
+++ b/pkg/mock/asglifecycle/asglifecycle.go
@@ -1,0 +1,89 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package asglifecycle
+
+import (
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	cfg "github.com/aws/amazon-ec2-metadata-mock/pkg/config"
+	"github.com/aws/amazon-ec2-metadata-mock/pkg/server"
+)
+
+const (
+	targetLifeCycleStatePath = "/latest/meta-data/autoscaling/target-lifecycle-state"
+)
+
+var (
+	eligibleIPs          = make(map[string]bool)
+	c                    cfg.Config
+	autoscalingStartTime int64 = time.Now().Unix()
+	state                      = "InService"
+)
+
+func Mock(config cfg.Config) {
+	SetConfig(config)
+	server.ListenAndServe(config.Server.HostName, config.Server.Port)
+}
+
+// SetConfig sets the local config
+func SetConfig(config cfg.Config) {
+	c = config
+}
+
+// Handler processes http requests
+func Handler(res http.ResponseWriter, req *http.Request) {
+	if c.MockIPCount >= 0 {
+		// req.RemoteAddr is formatted as IP:port
+		requestIP := strings.Split(req.RemoteAddr, ":")[0]
+		if !eligibleIPs[requestIP] {
+			if len(eligibleIPs) < c.MockIPCount {
+				eligibleIPs[requestIP] = true
+			} else {
+				log.Printf("Requesting IP %s is not eligible for Spot ITN or Rebalance Recommendation because the max number of IPs configured (%d) has been reached.\n", requestIP, c.MockIPCount)
+				server.ReturnNotFoundResponse(res)
+				return
+			}
+		}
+	}
+
+	switch req.URL.Path {
+	case targetLifeCycleStatePath:
+		handleASGTargetLifecycleState(res, req)
+	}
+}
+
+func handleASGTargetLifecycleState(res http.ResponseWriter, req *http.Request) {
+	requestTime := time.Now().Unix()
+	if c.ASGTerminationTriggerTime != "" {
+		triggerTime, _ := time.Parse(time.RFC3339, c.ASGTerminationTriggerTime)
+		delayRemaining := triggerTime.Unix() - requestTime
+		if delayRemaining <= 0 {
+			state = "Terminated"
+		}
+	} else {
+		delayInSeconds := c.ASGTerminationDelayInSec
+		delayRemaining := delayInSeconds - (requestTime - autoscalingStartTime)
+		if delayRemaining <= 0 {
+			state = "Terminated"
+		}
+	}
+
+	switch req.Method {
+	case "GET":
+		server.FormatAndReturnTextResponse(res, state)
+	}
+}

--- a/pkg/mock/root/root.go
+++ b/pkg/mock/root/root.go
@@ -15,6 +15,7 @@ package root
 
 import (
 	cfg "github.com/aws/amazon-ec2-metadata-mock/pkg/config"
+	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/asglifecycle"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/events"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/mock/spot"
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/server"
@@ -26,6 +27,7 @@ func Mock(config cfg.Config) {
 	// set configs for subcommands
 	spot.SetConfig(config)
 	events.SetConfig(config)
+	asglifecycle.SetConfig(config)
 
 	server.ListenAndServe(config.Server.HostName, config.Server.Port)
 }

--- a/test/e2e/cmd/asglifecycle-test
+++ b/test/e2e/cmd/asglifecycle-test
@@ -1,0 +1,68 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+TEST_CONFIG_FILE="$SCRIPTPATH/testdata/aemm-config-integ.json"
+LIFECYCLE_STATE_TEST_PATH="http://$HOSTNAME:$AEMM_PORT/latest/meta-data/autoscaling/target-lifecycle-state"
+TERMINATION_DELAY=10
+
+function test_asglifecycle_paths() {
+  pid=$1
+  tput setaf $MAGENTA
+  health_check $LIFECYCLE_STATE_TEST_PATH
+  TOKEN=$(get_v2Token $MAX_TOKEN_TTL $AEMM_PORT)
+
+  actual_paths=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://$HOSTNAME:$AEMM_PORT/latest/meta-data)
+  expected_paths=$(cat $SCRIPTPATH/golden/asglifecycle/latest/meta-data/index.golden)
+
+  assert_value "$actual_paths" "$expected_paths" "test_asglifecycle_paths"
+
+  clean_up $pid
+}
+
+function test_asg_termination_delay() {
+  pid=$1
+  delay_in_sec=$2
+  tput setaf $MAGENTA
+  health_check $LIFECYCLE_STATE_TEST_PATH
+  TOKEN=$(get_v2Token $MAX_TOKEN_TTL $AEMM_PORT)
+
+  expected_state="InService"
+  response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $LIFECYCLE_STATE_TEST_PATH)
+  assert_value "$response" "$expected_state" "test_asglifecycle::asg-pre-delay_response"
+
+  # ensure no impact to mock-delay functionality
+  echo "⏲ Waiting on delay ⏲"
+  sleep $delay_in_sec
+  expected_state="Terminated"
+  response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $LIFECYCLE_STATE_TEST_PATH)
+  assert_value "$response" "$expected_state" "test_asglifecycle::asg-post-delay_response"
+
+  # Confirm response isn't empty
+  if [[ ! -z $response ]]; then
+    echo "✅ Verified post-delay response"
+  else
+    echo "❌ Failed delay: there should be a lifecycle change to Terminated after delay"
+    EXIT_CODE_TO_RETURN=1
+  fi
+
+  clean_up $pid
+}
+
+tput setaf $YELLOW
+echo "======================================================================================================"
+echo "🥑 Starting asg lifecycle integration tests $METADATA_VERSION"
+echo "======================================================================================================"
+
+start_cmd=$(create_cmd $METADATA_VERSION asglifecycle --port $AEMM_PORT)
+$start_cmd &
+ASG_PID=$!
+test_asglifecycle_paths $ASG_PID
+
+start_cmd=$(create_cmd $METADATA_VERSION asglifecycle --port $AEMM_PORT --asg-termination-delay-sec $TERMINATION_DELAY)
+$start_cmd &
+ASG_PID=$!
+test_asg_termination_delay $ASG_PID $TERMINATION_DELAY
+
+exit $EXIT_CODE_TO_RETURN
+

--- a/test/e2e/cmd/asglifecycle-test
+++ b/test/e2e/cmd/asglifecycle-test
@@ -30,7 +30,7 @@ function test_asg_termination_delay() {
   response=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" $LIFECYCLE_STATE_TEST_PATH)
   assert_value "$response" "$expected_state" "test_asglifecycle::asg-pre-delay_response"
 
-  # ensure no impact to mock-delay functionality
+  # ensure no impact to asg termination delay functionality
   echo "⏲ Waiting on delay ⏲"
   sleep $delay_in_sec
   expected_state="Terminated"

--- a/test/e2e/cmd/asglifecycle-test
+++ b/test/e2e/cmd/asglifecycle-test
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-TEST_CONFIG_FILE="$SCRIPTPATH/testdata/aemm-config-integ.json"
 LIFECYCLE_STATE_TEST_PATH="http://$HOSTNAME:$AEMM_PORT/latest/meta-data/autoscaling/target-lifecycle-state"
 TERMINATION_DELAY=10
 

--- a/test/e2e/golden/asglifecycle/latest/meta-data/index.golden
+++ b/test/e2e/golden/asglifecycle/latest/meta-data/index.golden
@@ -4,7 +4,6 @@ ami-manifest-path
 autoscaling/
 block-device-mapping/
 elastic-inference/
-events/
 hostname
 iam/
 instance-action
@@ -25,5 +24,4 @@ ramdisk-id
 reservation-id
 security-groups
 services/
-spot/
 tags/

--- a/test/e2e/testdata/output/aemm-config-used.json
+++ b/test/e2e/testdata/output/aemm-config-used.json
@@ -1,4 +1,6 @@
 {
+  "asg-termination-delay-sec" :0,
+  "asg-termination-trigger-time": "",
   "config-file": "$HOME/aemm-config.json",
   "dynamic": {
     "paths": {
@@ -96,6 +98,7 @@
       "services-partition": "/latest/meta-data/services/partition",
       "spot": "/latest/meta-data/spot/instance-action",
       "spot-termination-time": "/latest/meta-data/spot/termination-time",
+      "target-lifecycle-state": "/latest/meta-data/autoscaling/target-lifecycle-state",
       "userdata": "/latest/user-data"
     },
     "values": {


### PR DESCRIPTION
Issue #218

Description of changes:
1) Added core functionality for handling /latest/meta-data/autoscaling/target-lifecycle-state GET requests and changing state after set delay or trigger time. 
2) Updated README
3) Added unit tests for asglifecycle subcommand
4) Added e2e tests to test that asglifecycle target-lifecycle-state changes from InService to Terminated after delay

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
