### PR TITLE
Watch Config File And Reset When Changed

### DIFF
--- a/pkg/cmd/root/globalflags/globalflags.go
+++ b/pkg/cmd/root/globalflags/globalflags.go
@@ -21,6 +21,9 @@ const (
 	// SaveConfigToFileFlag - whether to save processed config from all input sources
 	SaveConfigToFileFlag = "save-config-to-file"
 
+	// WatchConfigFileFlag - whether to watch the config file for changes
+	WatchConfigFileFlag = "watch-config-file"
+
 	// MockDelayInSecFlag - spot itn delay in seconds, relative to the application start time
 	MockDelayInSecFlag = "mock-delay-sec"
 

--- a/pkg/cmd/root/globalflags/globalflags.go
+++ b/pkg/cmd/root/globalflags/globalflags.go
@@ -55,5 +55,5 @@ const (
 
 // GetTopLevelFlags returns the top level global flags
 func GetTopLevelFlags() []string {
-	return []string{ConfigFileFlag, SaveConfigToFileFlag, MockDelayInSecFlag, MockTriggerTimeFlag, MockIPCountFlag, Imdsv2Flag, RebalanceDelayInSecFlag, RebalanceTriggerTimeFlag, ASGTerminationDelayInSecFlag, ASGTerminationTriggerTimeFlag}
+	return []string{ConfigFileFlag, SaveConfigToFileFlag, WatchConfigFileFlag, MockDelayInSecFlag, MockTriggerTimeFlag, MockIPCountFlag, Imdsv2Flag, RebalanceDelayInSecFlag, RebalanceTriggerTimeFlag, ASGTerminationDelayInSecFlag, ASGTerminationTriggerTimeFlag}
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -32,6 +33,7 @@ import (
 	"github.com/aws/amazon-ec2-metadata-mock/pkg/cmd/spot"
 	cfg "github.com/aws/amazon-ec2-metadata-mock/pkg/config"
 	r "github.com/aws/amazon-ec2-metadata-mock/pkg/mock/root"
+	"github.com/aws/amazon-ec2-metadata-mock/pkg/server"
 )
 
 var (
@@ -120,6 +122,10 @@ func setupAndSaveConfig(cmd *cobra.Command, args []string) error {
 	saveConfigToFile()
 
 	if watchCfg := viper.GetBool(gf.WatchConfigFileFlag); watchCfg {
+		viper.OnConfigChange(func(_ fsnotify.Event) {
+			server.Reset()
+			cmdutil.RegisterHandlers(cmd, c)
+		})
 		viper.WatchConfig()
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -51,6 +51,7 @@ var (
 		gf.MockTriggerTimeFlag:           "",
 		gf.MockIPCountFlag:               2,
 		gf.SaveConfigToFileFlag:          false,
+		gf.WatchConfigFileFlag:           false,
 		gf.Imdsv2Flag:                    false,
 		gf.RebalanceDelayInSecFlag:       0,
 		gf.RebalanceTriggerTimeFlag:      "",

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -86,6 +86,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringP(gf.PortFlag, "p", "", "the HTTP port where the mock runs (default: 1338)")
 	cmd.PersistentFlags().StringP(gf.ConfigFileFlag, "c", "", "config file for cli input parameters in json format (default: "+cfg.GetDefaultCfgFileName()+")")
 	cmd.PersistentFlags().BoolP(gf.SaveConfigToFileFlag, "s", false, "whether to save processed config from all input sources in "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
+	cmd.PersistentFlags().BoolP(gf.WatchConfigFileFlag, "s", false, "whether to watch the config file "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
 	cmd.PersistentFlags().Int64P(gf.MockDelayInSecFlag, "d", 0, "spot itn delay in seconds, relative to the application start time (default: 0 seconds)")
 	cmd.PersistentFlags().String(gf.MockTriggerTimeFlag, "", "spot itn trigger time in RFC3339 format. This takes priority over "+gf.MockDelayInSecFlag+" (default: none)")
 	cmd.PersistentFlags().Int64P(gf.MockIPCountFlag, "x", 2, "number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event")
@@ -117,6 +118,10 @@ func setupAndSaveConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	saveConfigToFile()
+
+	if watchCfg := viper.GetBool(gf.WatchConfigFileFlag); watchCfg {
+		viper.WatchConfig()
+	}
 
 	return nil
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -128,6 +128,7 @@ func setupAndSaveConfig(cmd *cobra.Command, args []string) error {
 				log.Printf("Failed to reset config on config change: %v\n", err)
 				return
 			}
+			saveConfigToFile()
 			server.Reset()
 			cmdutil.RegisterHandlers(cmd, c)
 		})

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -123,6 +123,10 @@ func setupAndSaveConfig(cmd *cobra.Command, args []string) error {
 
 	if watchCfg := viper.GetBool(gf.WatchConfigFileFlag); watchCfg {
 		viper.OnConfigChange(func(_ fsnotify.Event) {
+			if err := injectViperConfig(); err != nil {
+				log.Printf("Failed to reset config on config change: %v\n", err)
+				return
+			}
 			server.Reset()
 			cmdutil.RegisterHandlers(cmd, c)
 		})

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -88,7 +88,7 @@ func NewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringP(gf.PortFlag, "p", "", "the HTTP port where the mock runs (default: 1338)")
 	cmd.PersistentFlags().StringP(gf.ConfigFileFlag, "c", "", "config file for cli input parameters in json format (default: "+cfg.GetDefaultCfgFileName()+")")
 	cmd.PersistentFlags().BoolP(gf.SaveConfigToFileFlag, "s", false, "whether to save processed config from all input sources in "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
-	cmd.PersistentFlags().BoolP(gf.WatchConfigFileFlag, "s", false, "whether to watch the config file "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
+	cmd.PersistentFlags().BoolP(gf.WatchConfigFileFlag, "w", false, "whether to watch the config file "+cfg.GetSavedCfgFileName()+" in $HOME or working dir, if homedir is not found (default: false)")
 	cmd.PersistentFlags().Int64P(gf.MockDelayInSecFlag, "d", 0, "spot itn delay in seconds, relative to the application start time (default: 0 seconds)")
 	cmd.PersistentFlags().String(gf.MockTriggerTimeFlag, "", "spot itn trigger time in RFC3339 format. This takes priority over "+gf.MockDelayInSecFlag+" (default: none)")
 	cmd.PersistentFlags().Int64P(gf.MockIPCountFlag, "x", 2, "number of IPs in a cluster that can receive a Spot Interrupt Notice and/or Scheduled Event")

--- a/pkg/cmd/root/root_test.go
+++ b/pkg/cmd/root/root_test.go
@@ -31,7 +31,7 @@ func TestNewCmdName(t *testing.T) {
 	h.Assert(t, expected == actual, fmt.Sprintf("Expected the name for root command to be %s, but was %s", expected, actual))
 }
 func TestNewCmdFlags(t *testing.T) {
-	expectedFlags := []string{"config-file", "save-config-to-file", "mock-delay-sec", "mock-trigger-time", "mock-ip-count", "hostname", "port", "imdsv2", "rebalance-delay-sec", "rebalance-trigger-time", "asg-termination-delay-sec", "asg-termination-trigger-time"}
+	expectedFlags := []string{"config-file", "save-config-to-file", "watch-config-file", "mock-delay-sec", "mock-trigger-time", "mock-ip-count", "hostname", "port", "imdsv2", "rebalance-delay-sec", "rebalance-trigger-time", "asg-termination-delay-sec", "asg-termination-trigger-time"}
 
 	cmd := NewCmd()
 	actualFlagSet := cmd.PersistentFlags()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -34,6 +34,7 @@ type Config struct {
 	MockTriggerTime           string `mapstructure:"mock-trigger-time"`
 	MockIPCount               int    `mapstructure:"mock-ip-count"`
 	SaveConfigToFile          bool   `mapstructure:"save-config-to-file"`
+	WatchConfigFile           bool   `mapstructure:"watch-config-file"`
 	Server                    Server `mapstructure:"server"`
 	Imdsv2Required            bool   `mapstructure:"imdsv2"`
 	RebalanceDelayInSec       int64  `mapstructure:"rebalance-delay-sec"`

--- a/pkg/server/httpserver.go
+++ b/pkg/server/httpserver.go
@@ -62,7 +62,7 @@ const UnauthorizedResponse = `<?xml version="1.0" encoding="UTF-8"?>
 var (
 	// Routes represents the list of routes served by the http server
 	Routes []string
-	router = mux.NewRouter()
+	router = NewSwapper()
 )
 
 // HandlerType represents the function passed as an argument to HandleFunc
@@ -75,7 +75,12 @@ func HandleFunc(pattern string, requestHandler HandlerType) {
 
 // HandleFuncPrefix registers the handler function for the given prefix pattern
 func HandleFuncPrefix(pattern string, requestHandler HandlerType) {
-	router.PathPrefix(pattern).HandlerFunc(requestHandler)
+	router.HandleFuncPrefix(pattern, requestHandler)
+}
+
+// Reset resets the router swapper
+func Reset() {
+	router.Reset()
 }
 
 func listRoutes() {

--- a/pkg/server/swapper.go
+++ b/pkg/server/swapper.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/mux"
+)
+
+var _ http.Handler = (*swapper)(nil)
+
+// swapper is an `http.Handler` which allows the user to swap out routers while the server is running.
+// This enables us to reset routes as the program is running, allowing for functionality like updating the config.
+type swapper struct {
+	mu     sync.Mutex
+	router *mux.Router
+}
+
+func NewSwapper() *swapper {
+	return &swapper{
+		mu:     sync.Mutex{},
+		router: mux.NewRouter(),
+	}
+}
+
+func (rs *swapper) Reset() {
+	rs.mu.Lock()
+	rs.router = mux.NewRouter()
+	rs.mu.Unlock()
+}
+
+func (rs *swapper) Walk(f func(route *mux.Route, r *mux.Router, ancestors []*mux.Route) error) {
+	rs.mu.Lock()
+	rs.router.Walk(f)
+	rs.mu.Unlock()
+}
+
+func (rs *swapper) HandleFuncPrefix(pattern string, requestHandler HandlerType) {
+	rs.mu.Lock()
+	rs.router.PathPrefix(pattern).HandlerFunc(requestHandler)
+	rs.mu.Unlock()
+}
+
+func (rs *swapper) HandleFunc(pattern string, requestHandler HandlerType) {
+	rs.mu.Lock()
+	rs.router.HandleFunc(pattern, requestHandler)
+	rs.mu.Unlock()
+}
+
+func (rs *swapper) Swap(newRouter *mux.Router) {
+	rs.mu.Lock()
+	rs.router = newRouter
+	rs.mu.Unlock()
+}
+
+func (rs *swapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rs.mu.Lock()
+	router := rs.router
+	rs.mu.Unlock()
+	router.ServeHTTP(w, r)
+}


### PR DESCRIPTION
Description of changes:

In the current version of the amazon-ec2-metadata-mock, the server is started, and everything is static from the moment that it starts. This makes it impossible to make any changes based on outside factors, especially in testing conditions.

As an example - I'd like to combine the usage of this mock with LocalStack. In order to work with LocalStack's EC2 APIs, I need to set up subnets and security groups in my LocalStack container (this can be done on initialization of the tests. However, if the amazon-ec2-metadata-mock container is already running, I cannot update its subnet and security group ids to match the created resources in LocalStack.

This PR adds in config file watching via Viper's built in file-watcher, and adds in functionalities to allow us to reset the server's router and handlers whenever the configuration changes.

### Caveats

This PR adds in a simple naive Router Swapper implementation, which allows us to reset the handlers and router while the server is running. This does carry a performance penalty - however, as this is a tool meant for mocking and tests, I don't believe this should be a factor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
