### PR TITLE
Fix build-release-assets step in release workflow

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -18,7 +18,7 @@ RUN go mod download
 
 # Build
 COPY . .
-RUN go build -a -tags aemm-windows -o ./build/ ./cmd/...
+RUN go build -a -tags aemm-windows -o ./build/ec2-metadata-mock.exe ./cmd/...
 # In case the target is build for testing:
 # $ docker build  --target=builder -t test .
 ENTRYPOINT ["/amazon-ec2-metadata-mock/build/ec2-metadata-mock.exe"]

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean:
 
 compile:
 	@echo ${MAKEFILE_PATH}
-	go build -a -tags aemm${GOOS} -o ${BUILD_DIR_PATH}/ ./cmd/...
+	go build -a -tags aemm${GOOS} -o ${BUILD_DIR_PATH}/${BINARY_NAME} ./cmd/...
 
 validate-json:
 	${MAKEFILE_PATH}/scripts/validators/json-validator


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Use explicit output paths for binary artifacts.

- Test in local by: `make build-release-assets`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
