### PR TITLE
fix: network-card-index -> network-card

### DIFF
--- a/pkg/config/defaults/aemm-metadata-default-values.json
+++ b/pkg/config/defaults/aemm-metadata-default-values.json
@@ -31,7 +31,7 @@
       "mac-local-ipv4s": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/local-ipv4s",
       "mac-mac": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/mac",
       "mac-network-interface-id": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/interface-id",
-      "mac-network-interface-card-index": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/network-card-index",
+      "mac-network-interface-card-index": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/network-card",
       "mac-owner-id": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/owner-id",
       "mac-public-hostname": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/public-hostname",
       "mac-public-ipv4s": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/public-ipv4s",

--- a/test/e2e/golden/events/latest/meta-data/network/interfaces/macs/0e_49_61_0f_c3_11/index.golden
+++ b/test/e2e/golden/events/latest/meta-data/network/interfaces/macs/0e_49_61_0f_c3_11/index.golden
@@ -5,7 +5,7 @@ ipv6s
 local-hostname
 local-ipv4s
 mac
-network-card-index
+network-card
 owner-id
 public-hostname
 public-ipv4s

--- a/test/e2e/testdata/output/aemm-config-used.json
+++ b/test/e2e/testdata/output/aemm-config-used.json
@@ -66,7 +66,7 @@
       "mac-local-hostname": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/local-hostname",
       "mac-local-ipv4s": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/local-ipv4s",
       "mac-mac": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/mac",
-      "mac-network-interface-card-index": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/network-card-index",
+      "mac-network-interface-card-index": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/network-card",
       "mac-network-interface-id": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/interface-id",
       "mac-owner-id": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/owner-id",
       "mac-public-hostname": "/latest/meta-data/network/interfaces/macs/0e:49:61:0f:c3:11/public-hostname",


### PR DESCRIPTION
Description of changes:

The property `network-card-index` does not exist, it should be `network-card`. See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-categories

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
