### PR TITLE
Fix image for mock ip test

### DIFF
--- a/test/helm/mock-ip-count-test/test-pod-404.yaml
+++ b/test/helm/mock-ip-count-test/test-pod-404.yaml
@@ -7,7 +7,7 @@ spec:
   containers:
   - name: mock-ip-test
     imagePullPolicy: "IfNotPresent"
-    image: "mirror.gcr.io/library/centos:latest"
+    image: "quay.io/centos/centos:latest"
     command:
     - "bash"
     - "-c"

--- a/test/helm/mock-ip-count-test/test-pod.yaml
+++ b/test/helm/mock-ip-count-test/test-pod.yaml
@@ -7,7 +7,7 @@ spec:
   containers:
   - name: mock-ip-test
     imagePullPolicy: "IfNotPresent"
-    image: "mirror.gcr.io/library/centos:latest"
+    image: "quay.io/centos/centos:latest"
     command:
     - "bash"
     - "-c"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Fix image for mock ip test.

Google Container Registry is deprecated since 2025/03/18 ([ref](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr)). So our `build-and-test` starts failing.

Change to use red hat's container registry ([ref](https://www.centos.org/download/)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
