### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,6 +17,9 @@ env:
   DEFAULT_PY_VERSION: "3.9"
   IS_PUSH: ${{ github.event_name == 'push' }}
 
+permissions:
+  contents: read
+
 jobs:
   buildAndTest:
     name: Build and Test

--- a/.github/workflows/helm-chart-test.yaml
+++ b/.github/workflows/helm-chart-test.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 19 * * 1-5'
 
+permissions:
+  contents: read
+
 jobs:
   chartTests:
     name: Helm Chart Tests

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 17 * * *"  # Runs every day at 12:00PM CST
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.